### PR TITLE
Add standalone page for eng-ed section home

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -1,0 +1,7 @@
+---
+title: Engineering Education
+description: Resources created by engineers, for engineers.
+---
+<p>
+  Section partners with university students in Computer Science related fields of study to research and write about topics that are relevant to engineers in the modern technology landscape. You can find more information and program guidelines in the <a style="text-decoration: none;" href="https://github.com/section-io/engineering-education"><span class="text-light-blue decoration-none">GitHub repository</span></a>. If you're currently enrolled in a Computer Science related field of study and are interested in participating in the program, please complete <a style="text-decoration: none;" href="https://docs.google.com/forms/d/e/1FAIpQLSfTbj3kqvEJEb5RLjqJurfbHa8ckzQx0CjRzaizblue9ZOK5A/viewform?usp=sf_link"><span class="text-light-blue decoration-none">this form</span></a>
+</p>


### PR DESCRIPTION
Allows the copy to be re-used across HTML + RSS.