### PR TITLE
Rework metadata, so author pages work

### DIFF
--- a/articles/_index.md
+++ b/articles/_index.md
@@ -5,4 +5,5 @@ aliases:
   - '/engineering-education/building-chatbots-using-nlp/'
   - '/engineering-education/ddos-attacks-using-botnets/'
   - '/engineering-education/kubernetes-as-a-service/'
+type: articles
 ---

--- a/articles/_index.md
+++ b/articles/_index.md
@@ -2,7 +2,7 @@
 title: Section Engineering Education
 description: Resources created by engineers for engineers
 aliases:
-- "/engineering-education/building-chatbots-using-nlp/"
-- "/engineering-education/ddos-attacks-using-botnets/"
-- "/engineering-education/kubernetes-as-a-service/"
+  - '/engineering-education/building-chatbots-using-nlp/'
+  - '/engineering-education/ddos-attacks-using-botnets/'
+  - '/engineering-education/kubernetes-as-a-service/'
 ---

--- a/articles/abstraction-concepts-part2/index.md
+++ b/articles/abstraction-concepts-part2/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: abstraction-concepts-part2
+url: /engineering-education/abstraction-concepts-part2/
 title: Understanding Abstraction in Python, Part 2
 description: A concise look at abstraction principles with corresponding code examples. Polymorphism, encapsulation, methods and attributes, subclasses and superclasses, and inheritance.
 author: sophia-raji

--- a/articles/abstraction-concepts/index.md
+++ b/articles/abstraction-concepts/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: abstraction-concepts
+url: /engineering-education/abstraction-concepts/
 title: Understanding Abstraction in Python, Part 1
 description: An introduction to abstraction in Python through the concepts of parameters, scoping, and recursion.
 author: sophia-raji

--- a/articles/address-resolution-protocol/index.md
+++ b/articles/address-resolution-protocol/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: address-resolution-protocol
+url: /engineering-education/address-resolution-protocol/
 title: Introduction to Address Resolution Protocol(ARP) and its Types
 description: This article briefly introduces Address Resolution Protocol(ARP) and its types, namely, Gratuitous ARP(GARP), Inverse ARP(InARP), Proxy ARP and Reverse ARP(RARP).
 author: shreya-a-n

--- a/articles/are-chiplets-the-future-of-computing/index.md
+++ b/articles/are-chiplets-the-future-of-computing/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: are-chiplets-the-future-of-computing
+url: /engineering-education/are-chiplets-the-future-of-computing/
 title: Are Chiplets the Future of Computing?
 description: Processors followed Moore's Law, which says that the number of transistors will double every two years. It is now being said that Moore's Law is coming to an end, especially with monolithic designs.
 author: gregory-manley

--- a/articles/artificial-intelligence-future/index.md
+++ b/articles/artificial-intelligence-future/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: artificial-intelligence-future
+url: /engineering-education/artificial-intelligence-future/
 title: Artificial Intelligence – Does it have a place in our future?
 description: description placeholder
 author: michael-zanoff

--- a/articles/assembly-part-2/index.md
+++ b/articles/assembly-part-2/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: assembly-part-2
+url: /engineering-education/assembly-part-2/
 title: Assembly Part 2 - Let's Write Assembly!
 description: Learning assembly language, is any low-level programming language in which there is a very strong correspondence between the instructions in the language and the architecture's machine code instructions.
 author: mike-white

--- a/articles/asynchronous-programming-in-rust/index.md
+++ b/articles/asynchronous-programming-in-rust/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: asynchronous-programming-in-rust
+url: /engineering-education/asynchronous-programming-in-rust/
 title: Asynchronous Programming in Rust
 description: Asynchronous programming is a method of programming that can allow multiple different things to be run concurrently. In Rust, it is accomplished using a high-level idea called a Future.
 author: zack-jorquera

--- a/articles/beginner-guide-to-git/index.md
+++ b/articles/beginner-guide-to-git/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: beginner-guide-to-git
+url: /engineering-education/beginner-guide-to-git/
 title: Beginner's Guide to Git
 description: This guide is intended to help any beginner get started with Git. Using the examples provided below, we will assume that we are starting a project from scratch and want to manage it with Git.
 author: parampreet-singh

--- a/articles/binary-search/index.md
+++ b/articles/binary-search/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: binary-search
+url: /engineering-education/binary-search/
 title: All About Binary Search
 description: Walk-through of a simple Binary Search implementation in Python and discussion of binary search time and space complexity.
 author: sophia-raji

--- a/articles/blockchain-as-a-database/index.md
+++ b/articles/blockchain-as-a-database/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: blockchain-as-a-database
+url: /engineering-education/blockchain-as-a-database/
 title: Blockchain as a database
 description: Blockchain is a distributed database existing on multiple computers at the same time. It is constantly growing as new sets of recordings, or 'blocks', are added to it.
 author: keerthi-v

--- a/articles/border-gateway-protocol/index.md
+++ b/articles/border-gateway-protocol/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: border-gateway-protocol
+url: /engineering-education/border-gateway-protocol/
 title: Border Gateway Protocol - Why do we need it and how does it work?
 description: A brief introduction to the Internet's Border Gateway Protocol, its functioning, capabilities and importance. 
 author: shreya-a-n

--- a/articles/breadth-first-search/index.md
+++ b/articles/breadth-first-search/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: breadth-first-search
+url: /engineering-education/breadth-first-search/
 title: Solving a Maze with Breadth First Search
 description: Pathfinding is a very common task in computing. It's used for directions, and enemy AI in video games. Breadth-first Search (BFS) is one pathfinding algorithm which we can use to solve a maze.
 author: mike-white

--- a/articles/breaking-down-load-balancers/index.md
+++ b/articles/breaking-down-load-balancers/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: breaking-down-load-balancers
+url: /engineering-education/breaking-down-load-balancers/
 title: Breaking Down Load Balancers
 description: By adding a load balancer to a web application you not only increase the amount of servers that support a single application, but you also increase the reliably of an application with backups and fallback servers.
 author: gregory-manley

--- a/articles/build-an-outlook-clone-using-react-hooks/index.md
+++ b/articles/build-an-outlook-clone-using-react-hooks/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: build-an-outlook-clone-using-react-hooks
+url: /engineering-education/build-an-outlook-clone-using-react-hooks/
 title: Building Outlook Clone with React Hooks
 description: This article helps developers get started with React by building an Outlook clone using React so that you can learn the fundamentals by getting hands-on with the code.
 author: lalithnarayan-c

--- a/articles/build-an-outlook-clone-using-react/index.md
+++ b/articles/build-an-outlook-clone-using-react/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: build-an-outlook-clone-using-react
+url: /engineering-education/build-an-outlook-clone-using-react/
 title: Building An Outlook Clone with React
 description: This article helps developers get started with React by building an Outlook clone using React so that you can learn the fundamentals by getting hands-on with the code.
 author: lalithnarayan-c

--- a/articles/building-serverless-contact-form/index.md
+++ b/articles/building-serverless-contact-form/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: building-serverless-contact-form
+url: /engineering-education/building-serverless-contact-form/
 title: Building a Serverless Contact Form with Google Cloud Functions
 description: A walk through on how to build a serverless contact form, using google cloud functions. Known as FaaS or functions as a service.
 author: saiharsha-balasubramaniam

--- a/articles/clustering-algorithms/index.md
+++ b/articles/clustering-algorithms/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: clustering-algorithms
+url: /engineering-education/clustering-algorithms/
 title: Basics of Clustering Algorithms
 description: Clustering algorithms are procedures for partitioning data into groups or clusters such that the clusters are distinct, and members of each cluster belong together.
 author: justin-osborne

--- a/articles/complex-event-processing/index.md
+++ b/articles/complex-event-processing/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: complex-event-processing
+url: /engineering-education/complex-event-processing/
 title: Complex Event Processing
 description: The demand for rapid, actionable decisions illustrates the importance for enabling technologies like Complex Event Processing (CEP).
 author: earl-potters

--- a/articles/computer-vision-straight-lines/index.md
+++ b/articles/computer-vision-straight-lines/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: computer-vision-straight-lines
+url: /engineering-education/computer-vision-straight-lines/
 title: Computer Vision - Straight Lines
 description: Computer vision is how computers can identify high-level information from images or videos. This article explores one of the more basic algorithms in computer vision – finding straight lines in images.
 author: zack-jorquera

--- a/articles/constructors-destructors/index.md
+++ b/articles/constructors-destructors/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: extending-classes
+url: /engineering-education/extending-classes/
 title: Constructors and Destructors (C++)
 description: Learn the difference between Constructors and Destructors with the help of code snippets. Understand the usage of explicit call, implicit call and constructor overloading.
 author: kanishkvardhan-a-n
@@ -10,17 +10,18 @@ date: 2020-08-05T00:00:00-05:00
 topics: [Languages]
 excerpt_separator: <!--more-->
 images:
-
   - url: /engineering-education/extending-classes/hero.jpg
     alt: extending classes example image
-
 ---
+
 While programming, the objects which hold certain data members and member functions have to be initialized before operating on them. This is usually done by member functions that initialize data members to predefined values. But there is a special member function in which the object initializes itself automatically when it is first constructed. This special member function is called a **constructor**.
+
 <!--more-->
 
 Substantially, a constructor defines a value to data members of the class. **A constructor is a special member function that is used to initialize objects of a class instantaneously when it is constructed.**
 
 ### Using and Declaring a Constructor
+
 - A constructor is a member function that has the same name as that of the class.
 - It is defined as any other member functions (both inside or outside) of the class.
 - Since a constructor just defines the value to a data member, there's no return type to it.
@@ -43,52 +44,57 @@ class demo
 ```
 
 ##### C++ program to demonstrate the use of a constructor
+
 Consider the program to find the area of a circle. The name of the class will be **demo**. The two member functions will be declared, one for **input** and one for **output**. Since the name of the constructor should be the same as that of the class, the name of the constructor will also be **demo**. When the constructor demo is declared, the initialization of the class objects is done automatically.
- ```C
+
+```C
 #include <iostream>
 #include<conio.h>
 using namespace std;
 
 class demo
 {
-   private:
-      double radius, pi;
-    public:
-      void input(double r);
-      double output();
-      demo();  
+  private:
+     double radius, pi;
+   public:
+     void input(double r);
+     double output();
+     demo();
 };
 
 demo::demo(void)    //constructor definition outside the class
 {
-    pi=3.142;
+   pi=3.142;
 }
 void demo::input(double r)
 {
-   radius=r;
+  radius=r;
 }
 double demo::output(void)
 {
-   return (pi*radius*radius);
+  return (pi*radius*radius);
 }
 
 int main()
 {
-   demo d1;
+  demo d1;
 
-   d1.input(5.5);
-   cout<<"Area of the circle is : "<<d1.output()<<"sq.units"<<"\n";
-   return 0;
-   getch();
+  d1.input(5.5);
+  cout<<"Area of the circle is : "<<d1.output()<<"sq.units"<<"\n";
+  return 0;
+  getch();
 }
 ```
+
 The output of the above program is:
 
 ```bash
 Area of the circle is : 95.0455sq.units
 
 ```
+
 The above program can also be written by defining the constructor inside the class. The code segment for defining the constructor inside the class is as follows:
+
 ```C
 class demo
 {
@@ -103,47 +109,59 @@ class demo
             }
 };
 ```
-### Types of Constructors
-#### Default Constructor
-*A constructor which does not have any arguments is called a Default Constructor*, or a ‘Zero Argument Constructor’. In a default constructor, every object in the class is initialized to the same set of values. It is not possible to initialize different objects with different initial values. This is one of the disadvantages of a default constructor.
 
-**Syntax:**
-Consider a class with the name **world**. The default constructor for this class would be:
+### Types of Constructors
+
+#### Default Constructor
+
+_A constructor which does not have any arguments is called a Default Constructor_, or a ‘Zero Argument Constructor’. In a default constructor, every object in the class is initialized to the same set of values. It is not possible to initialize different objects with different initial values. This is one of the disadvantages of a default constructor.
+
+**Syntax:** Consider a class with the name **world**. The default constructor for this class would be:
+
 ```C
 world :: world()   //default constructor without any arguments
 ```
+
 **Note:** Any constructor with arguments is not a default constructor.
 
 #### Parameterized constructor
-*To avoid the infeasibility of default constructor to accept arguments, we use Parameterized Constructor, which is a constructor that can accept one or more arguments.* It works the same way as a default constructor, but the difference is that it can hold arguments. They are also called automatically once the objects are created. Another attribute of parameterized constructors is that they can be overloaded.  
 
-**Syntax:**
-Consider a class with the name world. The parameterized constructor for this class would be:
+_To avoid the infeasibility of default constructor to accept arguments, we use Parameterized Constructor, which is a constructor that can accept one or more arguments._ It works the same way as a default constructor, but the difference is that it can hold arguments. They are also called automatically once the objects are created. Another attribute of parameterized constructors is that they can be overloaded.
+
+**Syntax:** Consider a class with the name world. The parameterized constructor for this class would be:
+
 ```C
 world :: world(int a, int b)     //parameterized constructor with arguments
 ```
 
 #### Copy Constructor
-*Copy Constructor is a type of parameterized constructor in which the properties of one object can be copied to another object.* It is used to initialize an object with the values of already existing objects. A copy constructor is invoked when an existing object is passed as a parameter.
+
+_Copy Constructor is a type of parameterized constructor in which the properties of one object can be copied to another object._ It is used to initialize an object with the values of already existing objects. A copy constructor is invoked when an existing object is passed as a parameter.
 
 **Note:** Copy constructors cannot be invoked explicitly.
 
-**Syntax:**
-Consider a class with the name **world**. The copy constructor for this class would be:
+**Syntax:** Consider a class with the name **world**. The copy constructor for this class would be:
+
 ```C
 world :: world(world &ptr)        //copy constructor
 ```
-Where, `ptr` is the pointer to the class object.  
+
+Where, `ptr` is the pointer to the class object.
 
 ### Invoking (Calling) Constructors
+
 #### Explicit Call
+
 Explicit call is a method of invoking constructors in which the declaration of an object is done by using **assignment operator(=)**, constructor name followed by argument list.
 
 **Syntax:**
+
 ```
 constructor_name object_name=constructor_name(argument list);
 ```
+
 ##### C++ program to demonstrate the use of explicit call
+
 Consider the program to calculate the area of the circle. The name of the class and constructor will be **demo**. The constructor will be parameterized by taking one argument. Here, **d1** acts as the object which transfers the value **5.5** explicitly to the constructor.
 
 ```C
@@ -175,19 +193,27 @@ int main()
 	getch();
 }
 ```
+
 The output of the above program will be:
+
 ```bash
 The area of the circle is: 95.0455sq.units
 ```
+
 #### Implicit Call
+
 Implicit call is a method of invoking constructors in which the declaration of an object is done and is then followed by an argument list.
 
 **Syntax:**
+
 ```
 constructor_name object_name(argument list);
 ```
+
 ##### C++ program to demonstrate the use of implicit call
+
 Consider the program to calculate the area of the circle. The name of the class and constructor will be **demo**. The constructor will be parameterized by taking one argument. Here, **d1** acts as the object which transfers the value **5.5** implicitly to the constructor.
+
 ```C
 #include <iostream>
 #include<conio.h>
@@ -217,13 +243,17 @@ int main()
 	getch();
 }
 ```
+
 The output of the above program will be:
+
 ```bash
 The area of the circle is: 95.0455sq.units
 ```
+
 **Note:** For different values, different objects have to be initialized in the main function.
 
 ### Constructor Overloading
+
 We know that constructors are used for initializing data members of the class. They can also be used for initializing specific input values to the data members. But this cannot be done by using default constructors, since they do not take any arguments. So, for this to happen the default constructors have to be overloaded, i.e. they should be initialized with additional arguments. The object initialization has to be done by keeping the number of arguments in mind. The compiler then decides which constructor to invoke depending on the argument list.
 
 Look at this simple segment. Consider the class name and constructor name to be **demo**.
@@ -235,14 +265,16 @@ class demo
 			... data members of the class...
 		public:
 			demo()                 //default constructor
-			{ }                         
+			{ }
 			demo(argument list)   //parameterized constructor
 			{
 			...operations on the variables...
 			}
 	};
 ```
+
 Consider **d1** and **d2** to be the objects. When the object **d1** is created, default constructor is invoked, and when the object **d2** is created with some arguments, parameterized constructor is invoked.
+
 ```C
 int main()
 {
@@ -251,7 +283,9 @@ int main()
 	getch();
 }
 ```
-### Destructors                                                    
+
+### Destructors
+
 As mentioned in the introduction, constructor is a special member function which is instantaneously called whenever an object is created. Likewise, **a destructor is a type of function which is instantaneously called whenever an object is destroyed.** By doing so, it deallocates the values initialized to a variable and also its memory. They have no return value. They do not take any arguments and so they cannot be overloaded. It has the same name as the class (like a constructor), but is preceded by **tilde mark** (symbolized as ~). Look at the following code snippet to see how a destructor works.
 
 ```C
@@ -266,5 +300,6 @@ class demo
 ```
 
 ### Additional Resources
+
 - [C++ Class Constructor and Destructor](https://www.tutorialspoint.com/cplusplus/cpp_constructor_destructor.htm)
 - [Difference between Constructor and Destructor in C++](https://www.geeksforgeeks.org/difference-between-constructor-and-destructor-in-c/)

--- a/articles/crap-design/index.md
+++ b/articles/crap-design/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: crap-design
+url: /engineering-education/crap-design/
 title: From Crap Design to CRAP Design
 description: Even if you're a non-designer, you can still make a beautiful looking webpage for your project. Here are some tips to show you how- talking about contrast, repetition, alignment, proximity.
 author: mike-white

--- a/articles/creating-professional-email/index.md
+++ b/articles/creating-professional-email/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: creating-professional-email
+url: /engineering-education/creating-professional-email/
 title: How to Create a Professional Email - Setting up GSuite
 description: Shows how to set up GSuite with MX records and configuring SPF, DKIM and DMARC to authenticate and prevent spam emails and making sure your emails are received.
 author: louise-findlay

--- a/articles/cross-platform-applications-electron/index.md
+++ b/articles/cross-platform-applications-electron/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: cross-platform-applications-electron
+url: /engineering-education/cross-platform-applications-electron/
 title: Cross-Platform Applications With Electron
 description: Electron is an open-source software framework developed and maintained by GitHub. It allows for the development of desktop GUI applications using web technologies.
 author: rohan-reddy

--- a/articles/css-flexbox/index.md
+++ b/articles/css-flexbox/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: css-flexbox
+url: /engineering-education/css-flexbox/
 title: Create Layouts for Websites using CSS Flexbox
 description: CSS Flexbox is a one-dimensional layout system for creating layouts for webpages. It is used to align and define element behavior across a row or a column.
 author: saiharsha-balasubramaniam

--- a/articles/data-science-libraries-python/index.md
+++ b/articles/data-science-libraries-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: data-science-libraries-python
+url: /engineering-education/data-science-libraries-python/
 title: Popular Data Science Libraries used in Python
 description: This is an article about the popular data science libraries used in Python, and how developers are using them for analysis.
 author: richu-thomas

--- a/articles/data-structures-python-part-1/index.md
+++ b/articles/data-structures-python-part-1/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: data-structures-python-part-1
+url: /engineering-education/data-structures-python-part-1/
 title: Data Structures in Python - Part 1
 description: An overview of data structures in this article, and move on to learn about every data structure, and its implementation in Python throughout this series.
 author: saiharsha-balasubramaniam

--- a/articles/data-studio/index.md
+++ b/articles/data-studio/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: data-studio
+url: /engineering-education/data-studio/
 title: Introduction to Data Studio
 description: An Introduction to Data Studio - a free cloud based data visualization tool platform by Google to transform data sets to life.
 author: rohan-reddy

--- a/articles/data-visualization-with-d3js/index.md
+++ b/articles/data-visualization-with-d3js/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: data-visualization-with-d3js
+url: /engineering-education/data-visualization-with-d3js/
 title: Data Visualization with D3.js
 description: D3 (Data-Driven Documents) is a JavaScript library that allows us to manipulate documents based on data. This tutorial walks through how to visualize data using D3.js.
 author: rohan-reddy

--- a/articles/denial-of-service/index.md
+++ b/articles/denial-of-service/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: denial-of-service
+url: /engineering-education/denial-of-service/
 title: What is a Denial of Service Attack?
 description: A Denial of Service attack is a cyber-attack in which the perpetrator seeks to make a machine or network and resource unavailable to its intended users by temporarily or indefinitely disrupting services to the host connected to the Internet.
 author: richu-thomas

--- a/articles/deploying-nodejs-web-app/index.md
+++ b/articles/deploying-nodejs-web-app/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: deploying-nodejs-web-app
+url: /engineering-education/deploying-nodejs-web-app/
 title: Deploying Your First Node.js Web App
 description: This guide provides an introduction to Node.js and NPM and how to get a basic Express server running to serve static web files. Aimed at front-end developers (who can already create basic websites using HTML, CSS and JS.)
 author: louise-findlay

--- a/articles/dna-computing/index.md
+++ b/articles/dna-computing/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: dna-computing
+url: /engineering-education/dna-computing/
 title: Introduction to DNA Computing and its Applications
 description: The article introduces to DNA computing, natural computing based on the concept of performing logical and arithmetic operations using molecular properties of DNA.
 author: aditi-jayakumar

--- a/articles/docker-concepts/index.md
+++ b/articles/docker-concepts/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: docker-concepts
+url: /engineering-education/docker-concepts/
 title: Understanding Docker Concepts
 description: The basic concepts of Docker, technology and has helped drive the trend towards containerization and micro-services in software development that’s known as cloud-native development.
 author: francisca-adekanye

--- a/articles/document-object-model/index.md
+++ b/articles/document-object-model/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: document-object-model
+url: /engineering-education/document-object-model/
 title: Understanding Document Object Model (DOM)
 description: Document object model (DOM) is a structure which acts as the framework of a standard HTML (HyperText Markup Language). DOM is a programming API for HTML and XML documents.
 author: kanishkvardhan-a-n

--- a/articles/edge-tf-lite/index.md
+++ b/articles/edge-tf-lite/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: edge-tf-lite
+url: /engineering-education/edge-tf-lite/
 title: Machine Learning on Edge Devices Using TensorFlow Lite
 description: This article details machine learning on edge computing devices which use TensorFlow Lite and RaspberryPi. Talking about the advantages of on-device machine learning inference such as Latency, Bandwidth, privacy, and security.
 author: rohan-reddy

--- a/articles/elliptical-curve-cryptography/index.md
+++ b/articles/elliptical-curve-cryptography/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: elliptical-curve-cryptography
+url: /engineering-education/elliptical-curve-cryptography/
 title: How Does Elliptical Curve Cryptography Work?
 description:  Elliptical curve cryptography is a next-generation public key cryptography system that provides a significant increase in security over previous generations.
 author: gregory-manley

--- a/articles/end-to-end-encryption/index.md
+++ b/articles/end-to-end-encryption/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: end-to-end-encryption
+url: /engineering-education/end-to-end-encryption/
 title: End-to-End Encryption (E2EE) Explained
 description: End-to-end encryption (E2EE) is a a public key encryption system that prevents the contents of your messages, text, and files from being understood by anyone except their intended recipients.
 author: earl-potters

--- a/articles/event-loop-explained/index.md
+++ b/articles/event-loop-explained/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: event-loop-explained
+url: /engineering-education/event-loop-explained/
 title: The Event Loop Explained
 description: The event loop is not just for JavaScript. It is the standard that defines how a web browser front end works. Understanding the event loop is the first step to creating great web-based software.
 author: nadiv-gold-edelstein

--- a/articles/evolution-of-wifi6/index.md
+++ b/articles/evolution-of-wifi6/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: evolution-of-wifi6
+url: /engineering-education/evolution-of-wifi6/
 title: The Evolution of Wi-Fi 6
 description: Wi-Fi 6 has arrived, providing faster speeds, higher volume device support, and advanced security protocols.
 author: gregory-manley

--- a/articles/extending-classes/index.md
+++ b/articles/extending-classes/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: extending-classes
+url: /engineering-education/extending-classes/
 title: Extending Classes (C++)
 description: This article introduces the basic concepts of Inheritance, different types of class derivations and friend functions with code snippets in C++.
 author: kanishkvardhan-a-n

--- a/articles/fiber-optic-communication/index.md
+++ b/articles/fiber-optic-communication/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: fiber-optic-communication
+url: /engineering-education/fiber-optic-communication/
 title: Fiber Optic Communication - What is it and why is it beneficial?
 description: Using light to transmit data, fiber optics are one of the most powerful technologies facilitating communication in today's fast-paced world.
 author: michael-zanoff

--- a/articles/function-overloading/index.md
+++ b/articles/function-overloading/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: function-overloading
+url: /engineering-education/function-overloading/
 title: Function Overloading (C++)
 description: A brief introduction to the Function Overloading, Polymorphism and Inline functions with code snippets. Object Oriented Programming is a fundamental method of programming which helps to develop programs using a modular approach.
 author: kanishkvardhan-a-n

--- a/articles/github-actions/index.md
+++ b/articles/github-actions/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: github-actions
+url: /engineering-education/github-actions/
 title: Introduction to GitHub Actions
 description: We can use GitHub Actions to perform real-world tasks such as CI/CD, publish to NPM, deploy to the cloud, and so on. This guide will walk you through how to get started with GitHub Actions.
 author: rohan-reddy

--- a/articles/golang-part-1-introduction/index.md
+++ b/articles/golang-part-1-introduction/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: golang-part-1-introduction
+url: /engineering-education/golang-part-1-introduction/
 title: Introduction to Golang
 description:  It covers the history of Golang, its purpose, where it is used, and how to install -  Go is  similar to C but with memory safety.
 author: adith-bharadwaj

--- a/articles/golang-part-2-programming-basics/index.md
+++ b/articles/golang-part-2-programming-basics/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: golang-part-2-programming-basics
+url: /engineering-education/golang-part-2-programming-basics/
 title:  Golang - Programming Basics
 description: Covering the basics of programming in Go - directories, workspaces, variables, loops, conditionals and control flow, etc.
 author: adith-bharadwaj

--- a/articles/google-search-console-introduction/index.md
+++ b/articles/google-search-console-introduction/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: google-search-console-introduction
+url: /engineering-education/google-search-console-introduction/
 title: Google Search Console - An Introduction
 description: This guide to Google Search Console will teach you how to add a site (called a property), submit a sitemap, and find and fix any errors that the Google crawlers may come across.
 author: louise-findlay

--- a/articles/guide-to-create-mock-server/index.md
+++ b/articles/guide-to-create-mock-server/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: guide-to-create-mock-server
+url: /engineering-education/guide-to-create-mock-server/
 title: How to Create Your First Mock Server using Postman
 description: How to Create Your First Mock Server simulating APIs. It consists of all the extensive details, step-by-step instructions with images and resources links to help in the beginning of your open source deployment.
 author: aman-saxena

--- a/articles/history-of-blockchain/index.md
+++ b/articles/history-of-blockchain/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: history-of-blockchain
+url: /engineering-education/history-of-blockchain/
 title: The History of Blockchain
 description: Reverse proxies are servers that sit between the request-response process that ensure website application requests are redirected to the proper backend server.
 author: gregory-manley

--- a/articles/history-of-c-programming-language/index.md
+++ b/articles/history-of-c-programming-language/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: history-of-c-programming-language
+url: /engineering-education/history-of-c-programming-language/
 title: A Brief History of C Programming
 description: There are many offshoots of the C programming language, including Objective-C, C++, and C#. None of these are the same language. Here's a brief history of C.
 author: gregory-manley

--- a/articles/history-of-container-technology/index.md
+++ b/articles/history-of-container-technology/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: history-of-container-technology
+url: /engineering-education/history-of-container-technology/
 title: A Brief History of Container Technology
 description: A brief history of container technology and how it has fundamentally altered the development of software today.
 author: bora-basyildiz

--- a/articles/history-of-cryptoanarchy/index.md
+++ b/articles/history-of-cryptoanarchy/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: history-of-cryptoanarchy
+url: /engineering-education/history-of-cryptoanarchy/
 title: A History of Cryptoanarchy
 description: Overview of the anarchist philosophy and technologies predating Bitcoin.
 author: sophia-raji

--- a/articles/how-much-data-online/index.md
+++ b/articles/how-much-data-online/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: how-much-data-online
+url: /engineering-education/how-much-data-online/
 title: How Much Data Is on the Internet?
 description: How much data is on the Internet, how much information is online, and how is data on the internet stored?
 author: gregory-manley

--- a/articles/how-polygonal-graphics-are-made/index.md
+++ b/articles/how-polygonal-graphics-are-made/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: how-polygonal-graphics-are-made
+url: /engineering-education/how-polygonal-graphics-are-made/
 title: How Polygonal Graphics Are Made
 description: Polygons are used in computer graphics to compose images that are three-dimensional in appearance. Usually triangular polygons arise when an object's surface is modeled, vertices are selected, and the object is rendered in a wire frame model.
 author: nadiv-gold-edelstein

--- a/articles/how-to-build-chrome-extension/index.md
+++ b/articles/how-to-build-chrome-extension/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: how-to-build-chrome-extension
+url: /engineering-education/how-to-build-chrome-extension/
 title: How to Build Your First Chrome Extension
 description: This tutorial will provide fundamentals for building your first Chrome extension, empowering you to make any chrome extension that involves taking data/text from the page, running a script on it(or not) and replacing/altering it with something of your choosing.
 author: ria-thakkar

--- a/articles/how-to-build-your-own-private-blockchain/index.md
+++ b/articles/how-to-build-your-own-private-blockchain/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: how-to-build-your-own-private-blockchain
+url: /engineering-education/how-to-build-your-own-private-blockchain/
 title: How to Build Your Own Private Blockchain
 description: Private blockchains work based on access controls which restrict the people who can participate in the network. Instead of waiting for a network consensus, information can be recorded immediately.
 author: jethro-magaji

--- a/articles/how-to-start-competitive-programming/index.md
+++ b/articles/how-to-start-competitive-programming/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: how-to-start-competitive-programming
+url: /engineering-education/how-to-start-competitive-programming/
 title: How to Get Started with Competitive Programming
 description: Competitive programming is a mind sport usually held over the Internet or a local network, involving participants trying to program according to provided specifications.
 author: aman-saxena

--- a/articles/how-to-submit-your-first-article/index.md
+++ b/articles/how-to-submit-your-first-article/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: how-to-submit-your-first-article
+url: /engineering-education/how-to-submit-your-first-article/
 title: How to Submit Your First Article Using GitHub Desktop and VS Code
 description: A blog for the "How-To Guides" category about how to submit your first article for Section's Engineering Education (EngEd) Program using GitHub Desktop and VS Code.
 author: aman-saxena

--- a/articles/http-code-cheat-sheet/index.md
+++ b/articles/http-code-cheat-sheet/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: http-code-cheat-sheet
+url: /engineering-education/http-code-cheat-sheet/
 title: HTTP Code Cheat Sheet - What You Need to Know About HTTP Requests and Responses
 description: HTTP codes are important to understand, especially if you are developing a web application and are trying to debug based upon the console responses.
 author: gregory-manley

--- a/articles/impact-of-mathematics-on-programming/index.md
+++ b/articles/impact-of-mathematics-on-programming/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: impact-of-mathematics-on-programming
+url: /engineering-education/impact-of-mathematics-on-programming/
 title: The Impact of Mathematics on Programming
 description: Basic mathematics is necessary to be mastered by students taking a programming subject because it can promote problem solving and algorithmic thinking skills.
 author: dominic-nshimba

--- a/articles/install-a-gui-on-an-ubuntu-server-1804/index.md
+++ b/articles/install-a-gui-on-an-ubuntu-server-1804/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: install-a-gui-on-an-ubuntu-server-1804
+url: /engineering-education/install-a-gui-on-an-ubuntu-server-1804/
 title: How to Install a GUI on an Ubuntu Server 18.04 for Easier Remote Management
 description: A tutorial on installing Xfce or LXDE GUIs onto an Ubuntu Server 18.04 Installation for Easier Remote Management - Linux-based Virtual Private Server (VPS) runs off of a command line with no graphical user interface (GUI).
 author: gregory-manley

--- a/articles/installing-k8-ubuntu-server/index.md
+++ b/articles/installing-k8-ubuntu-server/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: installing-k8-ubuntu-server
+url: /engineering-education/installing-k8-ubuntu-server/
 title: How to Install a Single Node Kubernetes Cluster on Ubuntu
 description: Kubernetes is not limited to being installed only on Ubuntu server. It can be installed on Linux, Windows, and even macOS.
 author: gregory-manley

--- a/articles/introduction-quantum-computers/index.md
+++ b/articles/introduction-quantum-computers/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-quantum-computers
+url: /engineering-education/introduction-quantum-computers/
 title: Quantum Computers - Are they the future of computing?
 description: Computers that perform quantum computations are known as quantum computers. Quantum computing is the use of quantum-mechanical processing such as superposition and entanglement to perform computation.
 author: michael-zanoff

--- a/articles/introduction-to-cloud-computing/index.md
+++ b/articles/introduction-to-cloud-computing/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-to-cloud-computing
+url: /engineering-education/introduction-to-cloud-computing/
 title: Introduction To Cloud Computing
 description: Cloud computing is the on-demand availability of computer system resources, especially data storage and computing power, without direct active management by the user.
 author: francisca-adekanye

--- a/articles/introduction-to-jupyter-notebooks/index.md
+++ b/articles/introduction-to-jupyter-notebooks/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-to-jupyter-notebooks
+url: /engineering-education/introduction-to-jupyter-notebooks/
 title: Introduction to Jupyter Notebooks
 description: The article explores the basics of Jupyter notebooks, why they are used, how to install, run, and use Jupyter notebooks for a wide array of tasks.
 author: adith-bharadwaj

--- a/articles/introduction-to-kafka/index.md
+++ b/articles/introduction-to-kafka/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-to-kafka
+url: /engineering-education/introduction-to-kafka/
 title: Introduction to Kafka
 description: This article serves to introduces the readers to the basics of Kafka, its history, architecture, and installation.
 author: adith-bharadwaj
@@ -10,22 +10,23 @@ date: 2020-08-07T00:00:00-14:00
 topics: []
 excerpt_separator: <!--more-->
 images:
-
   - url: /engineering-education/introduction-to-kafka/hero.jpg
     alt: introduction-to-kafka
 ---
 
-*Kafka is a high-throughput distributed messaging system, owned and maintained by the [Apache software foundation](https://www.apache.org/), which has become one of the most popular open-source data processing tools in the world*. Kafka is used by many tech giants such as Uber, LinkedIn, Twitter, Netflix, etc for real-time processing of data. Before we install Kafka, it's important to understand its architecture and history. 
+_Kafka is a high-throughput distributed messaging system, owned and maintained by the [Apache software foundation](https://www.apache.org/), which has become one of the most popular open-source data processing tools in the world_. Kafka is used by many tech giants such as Uber, LinkedIn, Twitter, Netflix, etc for real-time processing of data. Before we install Kafka, it's important to understand its architecture and history.
 
 ### What is Kafka?
+
 #### History
-Kafka was developed by a team of engineers at [LinkedIn](https://engineering.linkedin.com/blog/2016/04/kafka-ecosystem-at-linkedin). *The engineers were trying to solve the problem of low-latency ingestion of large amounts of event data from the LinkedIn website*.
 
-**Event data** is data that is generated when users register to a website, login, follow people, or like and share posts. These actions are called user events, and companies like LinkedIn track these events performed by the users and analyze the data to gain insights on customer activities to increase their retention rate. LinkedIn generates massive amounts of event data every single day, and they wanted to process this data in real-time. 
+Kafka was developed by a team of engineers at [LinkedIn](https://engineering.linkedin.com/blog/2016/04/kafka-ecosystem-at-linkedin). _The engineers were trying to solve the problem of low-latency ingestion of large amounts of event data from the LinkedIn website_.
 
-Existing tools such as [RabbitMQ](https://www.rabbitmq.com/) and [ActiveMQ](http://activemq.apache.org/) were general-purpose [messaging queues](https://www.cloudamqp.com/blog/2014-12-03-what-is-message-queuing.html) that supported a wide range of protocols such as AMQP, MQTT, etc. *However, these messaging queues do not store the data once they are consumed*.
+**Event data** is data that is generated when users register to a website, login, follow people, or like and share posts. These actions are called user events, and companies like LinkedIn track these events performed by the users and analyze the data to gain insights on customer activities to increase their retention rate. LinkedIn generates massive amounts of event data every single day, and they wanted to process this data in real-time.
 
-Unlike other messaging systems, the message queue in Kafka is **persistent**, and data sent is stored until a specified retention period has passed. Kafka was designed for high-throughput, fast, and scalable data streaming and offers much **higher performance** with limited resources than message brokers like RabbitMQ and ActiveMQ. 
+Existing tools such as [RabbitMQ](https://www.rabbitmq.com/) and [ActiveMQ](http://activemq.apache.org/) were general-purpose [messaging queues](https://www.cloudamqp.com/blog/2014-12-03-what-is-message-queuing.html) that supported a wide range of protocols such as AMQP, MQTT, etc. _However, these messaging queues do not store the data once they are consumed_.
+
+Unlike other messaging systems, the message queue in Kafka is **persistent**, and data sent is stored until a specified retention period has passed. Kafka was designed for high-throughput, fast, and scalable data streaming and offers much **higher performance** with limited resources than message brokers like RabbitMQ and ActiveMQ.
 
 Apache Kafka is a **publish-subscribe** messaging platform, also called a message broker, designed to process [streaming data](https://aws.amazon.com/streaming-data/) in real-time and feed it for fast and scalable operations. It is a distributed streaming platform used for data processing, streaming analysis, data storage, and data visualization.
 
@@ -34,66 +35,73 @@ Kafka offers the ability to manage protocols across several clusters and store t
 Kafka is used for capturing big data and real-time analysis in a variety of applications, including data mining, analytics, data visualization, and machine learning.
 
 #### What is a publish-subscribe messaging system?
-*Publish-subscribe messaging is a method of communication in which messages are exchanged between the sender and the receiver where neither of them is aware of the other's identity*. In other words, the sender (also called Publisher or Producer) and the receiver (also called subscriber or consumer) are **independent** of each other and are loosely coupled. In this system, messages are durable and are highly available for processing.
 
-Unlike the point-to-point system where a particular message can only be consumed by one consumer, in this model, consumers can subscribe to one or more topics and consume all the messages on that topic. 
+_Publish-subscribe messaging is a method of communication in which messages are exchanged between the sender and the receiver where neither of them is aware of the other's identity_. In other words, the sender (also called Publisher or Producer) and the receiver (also called subscriber or consumer) are **independent** of each other and are loosely coupled. In this system, messages are durable and are highly available for processing.
+
+Unlike the point-to-point system where a particular message can only be consumed by one consumer, in this model, consumers can subscribe to one or more topics and consume all the messages on that topic.
 
 ![publish-subscribe](/engineering-education/introduction-to-kafka/publish-subscribe.png)
 
 ### Architecture and terminologies
+
 In Kafka, data is referred to as a message. In other words, a message refers to a stream or array of bytes that contain some information. These are some Kafka terminologies that we need to bear in mind:
 
 1. **Topics**
 
-*A topic is a name or a unique id given to a category or feed to which streams of records or messages are sent*. 
+_A topic is a name or a unique id given to a category or feed to which streams of records or messages are sent_.
 
 In Kafka, topics can have zero or more consumers that receive the data that is written to it. For example, if we want to send information about stocks, we can create a topic called "stocks", and multiple producers can send messages to that topic. The topic can also have multiple consumers collecting information about stock prices.
 
 2. **Brokers**
 
-*Brokers, also called Kafka nodes or Kafka servers, are responsible for facilitating between the producers and consumers*. They act as a "middleman" and store the data sent by the producer and allow the consumer to fetch the messages in a topic.
+_Brokers, also called Kafka nodes or Kafka servers, are responsible for facilitating between the producers and consumers_. They act as a "middleman" and store the data sent by the producer and allow the consumer to fetch the messages in a topic.
 
-In a Kafka cluster where multiple producers and consumers are interacting with each other, brokers are essential and act as a "load balancer". Brokers can have multiple partitions of topics, and these partitions can either be a leader or a replica(a message is replicated multiple times to provide fault tolerance). The leader is responsible for all writes and reads to a topic and coordinates with the other replicas. If something happens to the leader or it is unable to function, a replica becomes the new leader, thus providing fault-tolerance. 
+In a Kafka cluster where multiple producers and consumers are interacting with each other, brokers are essential and act as a "load balancer". Brokers can have multiple partitions of topics, and these partitions can either be a leader or a replica(a message is replicated multiple times to provide fault tolerance). The leader is responsible for all writes and reads to a topic and coordinates with the other replicas. If something happens to the leader or it is unable to function, a replica becomes the new leader, thus providing fault-tolerance.
 
 3. **producers**
 
-*Producers are applications that generate data and publish or send messages to one or more topics in Kafka brokers*. They do not send messages directly to the recipient. For example, if a producer generates stock data, it can write this data to a topic called "stocks" through the broker.  
+_Producers are applications that generate data and publish or send messages to one or more topics in Kafka brokers_. They do not send messages directly to the recipient. For example, if a producer generates stock data, it can write this data to a topic called "stocks" through the broker.
 
 4. **Consumers**
 
-*Consumers are applications that can read or receive data from one or more topics that they have subscribed to in a broker*. For example, if the producer writes to a topic called "stocks", the consumer can subscribe to that topic and pull all the messages from that topic through the broker. 
+_Consumers are applications that can read or receive data from one or more topics that they have subscribed to in a broker_. For example, if the producer writes to a topic called "stocks", the consumer can subscribe to that topic and pull all the messages from that topic through the broker.
 
 5. **Cluster**
 
-*Kafka shows its true potential when it used in a distributed system with multiple nodes working together*. A Kafka cluster is a set of two or more broker nodes. These clusters manage various activities and can efficiently distribute the load, therefore, providing high throughput and high availability. 
+_Kafka shows its true potential when it used in a distributed system with multiple nodes working together_. A Kafka cluster is a set of two or more broker nodes. These clusters manage various activities and can efficiently distribute the load, therefore, providing high throughput and high availability.
 
-Producers send data to a particular Kafka topic at regular intervals of time, and the broker stores these messages in different partitions. Consumers can subscribe to a specific topic and can consume messages through the broker. Zookeeper coordinates between the Kafka brokers and consumers that continuously consume the data. 
+Producers send data to a particular Kafka topic at regular intervals of time, and the broker stores these messages in different partitions. Consumers can subscribe to a specific topic and can consume messages through the broker. Zookeeper coordinates between the Kafka brokers and consumers that continuously consume the data.
 
-[Zookeeper](https://zookeeper.apache.org/) helps keep track of the various partitions, topics, and which nodes they are stored in so that the consumer can easily retrieve the location of a topic or a message. Kafka keeps track of messages being sent to the consumer by using **offsets**. Offsets are unique ids given to messages stored in a partition. The first message gets an offset of zero, the second message gets an offset of 1, and so on. If a consumer stops consuming messages, Kafka stores the most recent offset sent to the consumer. Once the consumer resumes pulling data, Kafka simply sends the message with the next offset value and resumes the operation. 
+[Zookeeper](https://zookeeper.apache.org/) helps keep track of the various partitions, topics, and which nodes they are stored in so that the consumer can easily retrieve the location of a topic or a message. Kafka keeps track of messages being sent to the consumer by using **offsets**. Offsets are unique ids given to messages stored in a partition. The first message gets an offset of zero, the second message gets an offset of 1, and so on. If a consumer stops consuming messages, Kafka stores the most recent offset sent to the consumer. Once the consumer resumes pulling data, Kafka simply sends the message with the next offset value and resumes the operation.
 
 ![architecture](/engineering-education/introduction-to-kafka/kafka-architecture.png)
 
 ### Installation
+
 Kafka requires Java (OpenJDK 8) on your system. Follow [this](https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-ubuntu-18-04#installing-specific-versions-of-openjdk) tutorial to install java.
 
 1. Kafka uses Zookeeper. Therefore, we first need to install Zookeeper on our systems. Download Zookeeper from the [official website](https://zookeeper.apache.org/releases.html)
 
 2. Extract the tar file.
+
 ```bash
 tar -zxf <zookeeper version>
-``` 
+```
 
 3. Download Kafka from the [official website](https://www.apache.org/dyn/closer.cgi?path=/kafka/2.5.0/kafka_2.12-2.5.0.tgz)
 
 4. Move the tar file to any convenient location in your system.
 
 5. Extract the tar file by running the following command:
+
 ```bash
 tar -xzf <kafka version that you downloaded>
 ```
-You have successfully installed Kafka on your system. 
+
+You have successfully installed Kafka on your system.
 
 ### Setting up a Kafka producer and consumer in Python
+
 Let us build a simple Kafka pipeline using the [kafka-python](https://pypi.org/project/kafka-python/) module that allows us to communicate with Kafka. To install kafka-python, run the following command on the terminal:
 
 ```bash
@@ -170,6 +178,6 @@ You will see "Hello world" displayed on the terminal.
 
 [Kafka vs RabbitMQ](https://www.upsolver.com/blog/kafka-versus-rabbitmq-architecture-performance-use-case)
 
-[Creating a message broker using Kafka](https://kafka.apache.org/quickstart) 
+[Creating a message broker using Kafka](https://kafka.apache.org/quickstart)
 
 [kafka-python docs](https://kafka-python.readthedocs.io/en/master/usage.html)

--- a/articles/introduction-to-mpls-and-mpls-vpn-technology/index.md
+++ b/articles/introduction-to-mpls-and-mpls-vpn-technology/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-to-mpls-and-mpls-vpn-technology
+url: /engineering-education/introduction-to-mpls-and-mpls-vpn-technology/
 title: Introduction to MPLS and MPLS VPN technology
 description: This article briefly introduces Multi-protocol Label Switching(MPLS) and talks about how Virtual Private Networks running on MPLS cores offer reliability, security and enhanced performance.
 author: shreya-a-n

--- a/articles/introduction-to-shell-scripting/index.md
+++ b/articles/introduction-to-shell-scripting/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-to-shell-scripting
+url: /engineering-education/introduction-to-shell-scripting/
 title: Introduction to Shell Scripting
 description: A shell script is a computer program designed to be run by the Unix shell. Typical operations performed by shell scripts include file manipulation, program execution, and printing text.
 author: rohan-reddy

--- a/articles/introduction-to-sitemaps/index.md
+++ b/articles/introduction-to-sitemaps/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-to-sitemaps
+url: /engineering-education/introduction-to-sitemaps/
 title: Does your website need a sitemap?
 description: Sitemapping allows a webmaster to inform search engines about URLs on a website that are available for crawling. A Sitemap is an XML file that lists the URLs for a site.
 author: gregory-manley

--- a/articles/introduction-to-spark/index.md
+++ b/articles/introduction-to-spark/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-to-spark
+url: /engineering-education/introduction-to-spark/
 title: Introduction to Apache Spark
 description: Introduction to the Apache Spark software library that is a framework that allows for the distributed processing of large data sets across clusters of computers using simple programming models.
 author: keerthi-v

--- a/articles/introduction-web-assembly-continued/index.md
+++ b/articles/introduction-web-assembly-continued/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-web-assembly-continued
+url: /engineering-education/introduction-web-assembly-continued/
 title: An Introduction to WebAssembly - Part 2
 description:   This article includes WebAssembly walk through the steps of building a react application the consumes a Wasm module.
 author: lucas-gompou

--- a/articles/introduction-web-assembly/index.md
+++ b/articles/introduction-web-assembly/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: introduction-web-assembly
+url: /engineering-education/introduction-web-assembly/
 title: An Introduction to WebAssembly - Part 1
 description: WebAssembly is designed as an open standard that defines a portable binary-code format for programming languages, and a corresponding textual assembly language. Enabling deployment on the web for client and server applications.
 author: lucas-gompou

--- a/articles/iot-and-cloud-computing-security-threats/index.md
+++ b/articles/iot-and-cloud-computing-security-threats/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: iot-and-cloud-computing-security-threats
+url: /engineering-education/iot-and-cloud-computing-security-threats/
 title: IOT and Cloud Computing Security Threats
 description: IoT and Cloud computing technologies communicate by sharing data that contain valuable information. However, the two technologies face challenges such as security issues.
 author: judy-nduati

--- a/articles/it-automation-using-ansible/index.md
+++ b/articles/it-automation-using-ansible/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: it-automation-using-ansible
+url: /engineering-education/it-automation-using-ansible/
 title: Automation Using Ansible
 description: IT automation using Ansible, article covers the basics of IT automation, how it is used, and why it is important. It also covers the basics of Ansible with the relevant code.
 author: adith-bharadwaj

--- a/articles/javascript-hoisting/index.md
+++ b/articles/javascript-hoisting/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: javascript-hoisting
+url: /engineering-education/javascript-hoisting/
 title: A Primer on JavaScript Hoisting
 description: Hoisting is when the JavaScript compiler changes the placement of variables and function in your code.
 author: nadiv-gold-edelstein

--- a/articles/keyword-extraction-in-python/index.md
+++ b/articles/keyword-extraction-in-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: keyword-extraction-in-python
+url: /engineering-education/keyword-extraction-in-python/
 title: Keyword Extraction in Python
 description: The article covers the basics of keywords extraction and introduces the users to a method called TF-IDF for extracting important words from a document.
 author: adith-bharadwaj

--- a/articles/linked-list-data-structure-python/index.md
+++ b/articles/linked-list-data-structure-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: linked-list-data-structure-python
+url: /engineering-education/linked-list-data-structure-python/
 title: Using the Linked List Data Structure in Python
 description: The linked list data structure is a linear data structure that is used to implement other data structures.
 author: saiharsha-balasubramaniam

--- a/articles/list-data-structure-python/index.md
+++ b/articles/list-data-structure-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: list-data-structure-python
+url: /engineering-education/list-data-structure-python/
 title: Using the List Data Structure in Python
 description: The list data structure is one of the most fundamental and powerful data structures in Python, allowing you to cut down on the lines of code you write.
 author: saiharsha-balasubramaniam

--- a/articles/low-level-javascript/index.md
+++ b/articles/low-level-javascript/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: low-level-javascript
+url: /engineering-education/low-level-javascript/
 title: Low Level JavaScript – The Magic of asm.js
 description: Low level means fast, and its hard to get faster than pure assembly. Asm.js, or Assembly JavaScript is a subset of normal JavaScript built to take advantage of certain aspects of JavaScript and low level techniques to squeeze every ounce of speed on the web.
 author: nadiv-gold-edelstein

--- a/articles/mainframes-vs-supercomputers/index.md
+++ b/articles/mainframes-vs-supercomputers/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: mainframes-vs-supercomputers
+url: /engineering-education/mainframes-vs-supercomputers/
 title: What is the difference between mainframes and supercomputers?
 description: Mainframes are powerful computers that have handled mission-critical business workloads for decades, but supercomputers take power to the next level.
 author: gregory-manley

--- a/articles/man-in-the-middle-attack/index.md
+++ b/articles/man-in-the-middle-attack/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: man-in-the-middle-attack
+url: /engineering-education/man-in-the-middle-attack/
 title: Man in the Middle Attacks Explained
 description: Man-in-the-middle (MitM) attacks happen at different levels and in different forms. This article explains what a MitM attack is and how to mitigate the risks of it occurring in you application.
 author: richu-thomas

--- a/articles/managing-heap/index.md
+++ b/articles/managing-heap/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: managing-heap
+url: /engineering-education/managing-heap/
 title: Managing the Heap in C
 description: Working with the heap in C is very difficult. Even Google struggles with it. But it's very important to not have memory issues in your code.
 author: mike-white

--- a/articles/matplotlib-visualization-python/index.md
+++ b/articles/matplotlib-visualization-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: matplotlib-visualization-python
+url: /engineering-education/matplotlib-visualization-python/
 title: Exploring Matplotlib for Visualizations in Python
 description: Covering numpy, matplotlib - exploring matplotlib features for data visualization in python. We cover the various use cases and generate 2-D, 3-D plots and various charts for data analysis.
 author: lalithnarayan-c

--- a/articles/network-design-open-source-vs-vendor-solutions/index.md
+++ b/articles/network-design-open-source-vs-vendor-solutions/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: network-design-open-source-vs-vendor-solutions
+url: /engineering-education/network-design-open-source-vs-vendor-solutions/
 title: Networking Decisions - Open Source vs. Vendor Solutions  
 description: An overview of open source vs vendor solutions to help engineers to make a more informed choice when selecting network equipment.
 author: aakash-rawal

--- a/articles/node-authentication-api/index.md
+++ b/articles/node-authentication-api/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: node-authentication-api
+url: /engineering-education/node-authentication-api/
 title: API Authentication with Node.js
 description: The article is about a basic authentication server with Node.js that gives API endpoints for authentication and provides a JSON web token with the login and signup requests.
 author: linus-muema

--- a/articles/node-mvc-architecture/index.md
+++ b/articles/node-mvc-architecture/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: node-mvc-architecture
+url: /engineering-education/node-mvc-architecture/
 title: Node.js applications following an MVC architecture
 description: The article is about creating your Node.js applications following an MVC architecture pattern that divides the whole application into three parts.
 author: linus-muema

--- a/articles/nodejs-environment-variables/index.md
+++ b/articles/nodejs-environment-variables/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: nodejs-environment-variables
+url: /engineering-education/nodejs-environment-variables/
 title: Environment Variables in Node.js
 description: Using the Node.js library dotenv to manage and load environment variables, we take a look at the purpose of environment variables, how to use them, and their role in a development environment.
 author: saiharsha-balasubramaniam

--- a/articles/obscure-html/index.md
+++ b/articles/obscure-html/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: obscure-html
+url: /engineering-education/obscure-html/
 title: Five Obscure but Useful HTML Tags
 description: This article details five obscure  and not often used but useful HTML tags - All these will work with HTML5 - need to use JavaScript to render it later.
 author: mike-white

--- a/articles/pos-system-using-arduino-and-python/index.md
+++ b/articles/pos-system-using-arduino-and-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: pos-system-using-arduino-and-python
+url: /engineering-education/pos-system-using-arduino-and-python/
 title: Point Of Sale Transaction System Using Arduino and Python
 description: Building a point of sale transaction system using Arduino and python using RFID-enabled ID cards to transact.
 author: lalithnarayan-c

--- a/articles/quantum-cryptography/index.md
+++ b/articles/quantum-cryptography/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: quantum-cryptography
+url: /engineering-education/quantum-cryptography/
 title: Is Quantum Cryptography the Future of Encryption?
 description: As momentum around quantum computing continues to build, will current encryption methods be able to stand up to the processing power? Quantum encryption aims to use quantum mechanics to protect data from hacking threats.
 author: justin-osborne

--- a/articles/queue-data-structure-python/index.md
+++ b/articles/queue-data-structure-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: queue-data-structure-python
+url: /engineering-education/queue-data-structure-python/
 title: Using the Queue Data Structure in Python
 description: A queue is an efficient linear data structure that is used to maintain the order and is used to implement other data structures. 
 author: saiharsha-balasubramaniam

--- a/articles/raising-exceptions/index.md
+++ b/articles/raising-exceptions/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: raising-exceptions
+url: /engineering-education/raising-exceptions/
 title: Raising Exceptions
 description: This article will go over how to manually throw exceptions in Python and use assertions for better debugging. Raising exceptions allows us to distinguish between regular events and something exceptional, such as errors.
 author: sophia-raji

--- a/articles/rest-api/index.md
+++ b/articles/rest-api/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: rest-api
+url: /engineering-education/rest-api/
 title: REST APIs - Introductory guide
 description: Introduction to REST APIs, what are they, why do we need them and how do they work. Representational state transfer is a software architectural style that defines a set of constraints to be used for creating Web services.
 author: priyank-kumar

--- a/articles/sentiment-analysis/index.md
+++ b/articles/sentiment-analysis/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: sentiment-analysis
+url: /engineering-education/sentiment-analysis/
 title: Sentiment Analysis of Twitter Data
 description: Sentiment analysis is the process of extracting the *sentiment* from a piece of text and to classify it as positive, negative or neutral accordingly.
 author: rohan-reddy

--- a/articles/serverless-api-firebase/index.md
+++ b/articles/serverless-api-firebase/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: serverless-api-firebase
+url: /engineering-education/serverless-api-firebase/
 title: Build a Serverless API using Firebase Functions
 description: This article walks a beginner through creating, writing and deploying a simple RESTful API using the firebase-cli tools onto a publicly hosted link.
 author: saiharsha-balasubramaniam

--- a/articles/setting-up-own-login-vs-login-via-external-services/index.md
+++ b/articles/setting-up-own-login-vs-login-via-external-services/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: setting-up-own-login-vs-login-via-external-services
+url: /engineering-education/setting-up-own-login-vs-login-via-external-services/
 title: Setting Up Own Login vs Login via External Services
 description: Setting Up Own Login vs Login via External Services - OAuth, JWT, Hashing and Salt, Brute-force attack, Rainbow Tables, IP Rate Limiting.
 author: abel-mathew

--- a/articles/setup-ssh-ubuntu-vm-aws/index.md
+++ b/articles/setup-ssh-ubuntu-vm-aws/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: setup-ssh-ubuntu-vm-aws
+url: /engineering-education/setup-ssh-ubuntu-vm-aws/
 title: How To Setup and SSH into an Ubuntu 18.04 Virtual Machine on AWS
 description: To check if the client is available on your Linux-based system, you will need to connect to an AWS account and a Linux machine or SSH client that you will use to SSH into the virtual machine.
 author: adrian-murage

--- a/articles/shuffle-a-list-algorithm/index.md
+++ b/articles/shuffle-a-list-algorithm/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: shuffle-a-list-algorithm
+url: /engineering-education/shuffle-a-list-algorithm/
 title:  How to Shuffle a List Using the Fisher-Yates Method
 description: In this step-by-step guide, we use the Fisher-Yates algorithm to shuffle a list using JavaScript.
 author: mike-white

--- a/articles/simple-guide-to-using-apis-nodejs/index.md
+++ b/articles/simple-guide-to-using-apis-nodejs/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: simple-guide-to-using-apis-nodejs
+url: /engineering-education/simple-guide-to-using-apis-nodejs/
 title: Getting to Grips with APIs - Using Node.js and EJS
 description: Using the Goodreads API and goodreads-api-node wrapper to search for books, display the results as book titles and create book pages when a book title is clicked upon.
 author: louise-findlay

--- a/articles/software-defined-networks/index.md
+++ b/articles/software-defined-networks/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: software-defined-networks
+url: /engineering-education/software-defined-networks/
 title: Transitioning from Traditional Networks to Software-Defined Networks (SDN)
 description: For an organization to effectively migrate to a software-defined network, IT administrators should embrace the advantages of SDN over a traditional network.
 author: aakash-rawal

--- a/articles/sorting-algorithms/index.md
+++ b/articles/sorting-algorithms/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: sorting-algorithms
+url: /engineering-education/sorting-algorithms/
 title: How to Sort a List Using Algorithms
 description: A sorting algorithm is an algorithm that puts elements of a list in a certain order. Efficient sorting is important to optimizing the efficiency of other algorithms that require input data to be in sorted lists.
 author: mike-white

--- a/articles/stack-data-structure-python/index.md
+++ b/articles/stack-data-structure-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: stack-data-structure-python
+url: /engineering-education/stack-data-structure-python/
 title: Using the Stack Data Structure in Python
 description: The Stack is a very powerful linear data structure that's used in many low level operating system programs. This article explores ways to implement and use the stack data structure in Python.
 author: saiharsha-balasubramaniam

--- a/articles/static-site-dynamic-nodejs-web-app/index.md
+++ b/articles/static-site-dynamic-nodejs-web-app/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: static-site-dynamic-nodejs-web-app
+url: /engineering-education/static-site-dynamic-nodejs-web-app/
 title: Converting A Static Site to A Dynamic Node.js Web App
 description: How to build your first dynamic Node.js web app from a static site. This article dispels the difficulties of learning full-stack development.
 author: louise-findlay

--- a/articles/tasks-to-docs/index.md
+++ b/articles/tasks-to-docs/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: tasks-to-docs
+url: /engineering-education/tasks-to-docs/
 title: Automating Tasks to Google Docs
 description: This article is a tutorial on how to build a python script that moves completed tasks from Google Tasks to Google Docs, within a given time-frame, categorized by date.
 author: keerthi-v

--- a/articles/telegram-bot-python/index.md
+++ b/articles/telegram-bot-python/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: telegram-bot-python
+url: /engineering-education/telegram-bot-python/
 title:  Building a Reddit Autoposter Telegram Bot with Python
 description: How to use Python to create a Telegram Bot that autoposts from a subreddit.
 author: saiharsha-balasubramaniam

--- a/articles/templating-your-static-site/index.md
+++ b/articles/templating-your-static-site/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: templating-your-static-site
+url: /engineering-education/templating-your-static-site/
 title: Templating Your Static Site (Converting a Static Site to a Static Site Generator)
 description: Tutorial on converting a simple static website to a static site generator, Eleventy and using EJS templating.
 author: louise-findlay

--- a/articles/testHK
+++ b/articles/testHK
@@ -1,1 +1,0 @@
-### Hello New World

--- a/articles/text-generation-nn/index.md
+++ b/articles/text-generation-nn/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: text-generation-nn
+url: /engineering-education/text-generation-nn/
 title: Text Generation With RNN + TensorFlow
 description: Text generation with an RNN. Contents. Setup. Import TensorFlow and other libraries. Download the Shakespeare dataset. Process the text. Vectorize the text. The prediction task. Build The Model. Try the model. Train the model.
 author: rohan-reddy

--- a/articles/the-first-iphone/index.md
+++ b/articles/the-first-iphone/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: the-first-iphone
+url: /engineering-education/the-first-iphone/
 title: The First iPhone
 description: Reverse proxies are servers that sit between the request-response process that ensure website application requests are redirected to the proper backend server.
 author: gregory-manley

--- a/articles/the-knapsack-problem/index.md
+++ b/articles/the-knapsack-problem/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: the-knapsack-problem
+url: /engineering-education/the-knapsack-problem/
 title: Breaking Down The Knapsack Problem
 description: In this article, we will discuss two approaches to the Knapsack Problem, including a pseudo-polynomial time solution using dynamic programming and different polynomial time approximations.
 author: ian-jorquera

--- a/articles/understanding-error-correcting-codes-part-1/index.md
+++ b/articles/understanding-error-correcting-codes-part-1/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: understanding-error-correcting-codes-part-1
+url: /engineering-education/understanding-error-correcting-codes-part-1/
 title: An Introduction to Error-Correcting Codes - Part 1
 description: Error-correcting codes are one of the most fundamental concepts that keep our technology-driven society running.
 author: ian-jorquera

--- a/articles/understanding-error-correcting-codes-part-2/index.md
+++ b/articles/understanding-error-correcting-codes-part-2/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: understanding-error-correcting-codes-part-2
+url: /engineering-education/understanding-error-correcting-codes-part-2/
 title: An Introduction to Error-Correcting Codes - Part 2
 description: Error-correcting codes are one of the most fundamental concepts that keep our technology-driven society running.
 author: ian-jorquera

--- a/articles/understanding-socket.io/index.md
+++ b/articles/understanding-socket.io/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: understanding-socket
+url: /engineering-education/understanding-socket/
 title: Understanding Socket.io
 description: Websocket is a computer communication protocol that enables full-duplex communication between the client and server over a single TCP connection. Socket.io is event based meaning that the client and server communicate through events.
 author: peter-kayere

--- a/articles/user-login-web-system/index.md
+++ b/articles/user-login-web-system/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: user-login-web-system
+url: /engineering-education/user-login-web-system/
 title: How to Create a User Login Web System in Python
 description: How to create a user login system to protect the website from unauthorized access using Python on Ubuntu Server 18.04.
 author: gregory-manley

--- a/articles/vlan-trunking/index.md
+++ b/articles/vlan-trunking/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: vlan-trunking
+url: /engineering-education/vlan-trunking/
 title: Overview of VLAN Trunking and Encapsulation
 description: This article briefly introduces Virtual Local Area Networks(VLANs) and their requirements. It discusses VLAN trunking and VLAN encapsulation using IEEE 802.1Q standard.
 author: shreya-a-n

--- a/articles/web-application-architectures-101/index.md
+++ b/articles/web-application-architectures-101/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: web-application-architectures-101
+url: /engineering-education/web-application-architectures-101/
 title: Web Application Architectures - 101
 description: Web Apps are everywhere. Let's look into their structure and how they interact with various services - looking at server side rendering, client side rendering, and universal or isomorphic applications.
 author: saiharsha-balasubramaniam

--- a/articles/web-application-firewall-bot-mitigation-comparison/index.md
+++ b/articles/web-application-firewall-bot-mitigation-comparison/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: web-application-firewall-bot-mitigation-comparison
+url: /engineering-education/web-application-firewall-bot-mitigation-comparison/
 title: Web Application Firewall vs Bot Mitigation Solutions
 description: Web application firewalls and bot mitigation solutions both provide tooling to help prevent malicious activity from affecting web applications, but what exactly does each do and how do they differ?
 author: ivan-santos

--- a/articles/webpack/index.md
+++ b/articles/webpack/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: webpack
+url: /engineering-education/webpack/
 title: Introduction To Webpack with Node.js
 description: This article serves as an Introduction to webpack - webpack is a static module bundler for modern JavaScript applications. 
 author: rohan-reddy

--- a/articles/wep-encryption/index.md
+++ b/articles/wep-encryption/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: wep-encryption
+url: /engineering-education/wep-encryption/
 title: Why You Shouldn't Use WEP Encryption
 description: Wired Equivalent Privacy (WEP) is a security algorithm for wireless networks. WEP encrypts all traffic using a static key, which means all traffic, no matter the device, is encrypted using the single key.
 author: gregory-manley

--- a/articles/what-are-reverse-proxies/index.md
+++ b/articles/what-are-reverse-proxies/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-are-reverse-proxies
+url: /engineering-education/what-are-reverse-proxies/
 title: What Are Reverse Proxies?
 description: Reverse proxies are servers that sit between the request-response process that ensure website application requests are redirected to the proper backend server.
 author: ivan-santos

--- a/articles/what-is-anti-virus-software/index.md
+++ b/articles/what-is-anti-virus-software/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-anti-virus-software
+url: /engineering-education/what-is-anti-virus-software/
 title: What is Anti-Malware?
 description: Anti-malware is software that protects the user from financial ruin, infrastructure destruction, loss of data or loss of consumer confidence, etc through sophisticated malware techniques in detection, containment and prevention.
 author: earl-potters

--- a/articles/what-is-bgp-anycast/index.md
+++ b/articles/what-is-bgp-anycast/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-bgp-anycast
+url: /engineering-education/what-is-bgp-anycast/
 title: What Is BGP Anycast and Where Is It Used?
 description: The Border Gateway Protocol (BGP) is a protocol which is used to determine the fastest path in which data will travel to reach its destination. BGP Anycast is a networking technique that allows different servers to share the same IP address.
 author: jonathan-popova-jones

--- a/articles/what-is-cors-policy/index.md
+++ b/articles/what-is-cors-policy/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-cors-policy
+url: /engineering-education/what-is-cors-policy/
 title: What is the CORS Policy?
 description: The CORS policy, or the Cross-Origin Resource Sharing policy, prevents accessing web resources from sources other than the server the website is running on for security purposes.
 author: nadiv-gold-edelstein

--- a/articles/what-is-css/index.md
+++ b/articles/what-is-css/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-css
+url: /engineering-education/what-is-css/
 title: What is CSS and Why Does it Matter?
 description: CSS is a very important part of the modern web. Without CSS, websites would look plain, uninteresting and dated by today's standards.
 author: gregory-manley

--- a/articles/what-is-kubernetes/index.md
+++ b/articles/what-is-kubernetes/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-kubernetes
+url: /engineering-education/what-is-kubernetes/
 title: What is Kubernetes?
 description: Kubernetes can expose a container using the DNS name or its own IP address. If traffic to a single container is high, Kubernetes is able to load balance and distribute the network traffic so that the deployment is stable.
 author: gregory-manley

--- a/articles/what-is-linux/index.md
+++ b/articles/what-is-linux/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-linux
+url: /engineering-education/what-is-linux/
 title: What is Linux?
 description: Initially released on September 17th, 1991, by Linux Torvalds, Linux is a set of open source Unix-like operating systems.
 author: jesus-nunez

--- a/articles/what-is-little-endian-and-big-endian/index.md
+++ b/articles/what-is-little-endian-and-big-endian/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-little-endian-and-big-endian
+url: /engineering-education/what-is-little-endian-and-big-endian/
 title: What Is Little-Endian And Big-Endian Byte Ordering?
 description: Computers store data in memory in binary. One thing that is often overlooked is the formatting at the byte level of this data. This is called endianness and it refers to the ordering of the bytes.
 author: zack-jorquera

--- a/articles/what-is-md5/index.md
+++ b/articles/what-is-md5/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-md5
+url: /engineering-education/what-is-md5/
 title: What Is MD5 and Why Is It Considered Insecure?
 description: MD5 Message-Digest Algorithm, is a cryptographic hashing function and is part of the Message Digest Algorithm family. It is insecure and should not be used in applications.
 author: gregory-manley

--- a/articles/what-is-pen-testing/index.md
+++ b/articles/what-is-pen-testing/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-pen-testing
+url: /engineering-education/what-is-pen-testing/
 title: What Is Pen Testing and Why Is It Important?
 description: Reverse proxies are servers that sit between the request-response process that ensure website application requests are redirected to the proper backend server.
 author: gregory-manley

--- a/articles/what-is-risc/index.md
+++ b/articles/what-is-risc/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: what-is-risc
+url: /engineering-education/what-is-risc/
 title: What is RISC?
 description: RISC, or Reduced Instruction Set Computer, is a type of microprocessor architecture that uses a small, highly-optimized set of instructions.
 author: gregory-manley

--- a/articles/when-to-use-vpn/index.md
+++ b/articles/when-to-use-vpn/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: when-to-use-vpn
+url: /engineering-education/when-to-use-vpn/
 title: What are VPNs and When Should You Use One?
 description: There are many reasons why someone might want to use a VPN, but some major reasons include security and the ability to bypass geographic restrictions.
 author: michael-zanoff

--- a/articles/why-ipv6-transition-is-important/index.md
+++ b/articles/why-ipv6-transition-is-important/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: why-ipv6-transition-is-important
+url: /engineering-education/why-ipv6-transition-is-important/
 title: Why is the Switch to IPv6 Important?
 description: Currently, communication through the Internet is primarily conducted using IPv4 addresses, but limited inventory of these addresses is demanding that we transition to IPv6 soon.
 author: gregory-manley

--- a/articles/working-with-databases-part1/index.md
+++ b/articles/working-with-databases-part1/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: working-with-databases-part1
+url: /engineering-education/working-with-databases-part1/
 title: Getting to Grips with Databases - Part 1
 description: Using MongoDB, this article proves that all you need to work with a database is some basic knowledge about the command line and JSON.
 author: louise-findlay

--- a/articles/working-with-databases-part2/index.md
+++ b/articles/working-with-databases-part2/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: working-with-databases-part2
+url: /engineering-education/working-with-databases-part2/
 title: Develop Your First Data-Driven Node.js Web App
 description: How to use Node.js, EJS and the MongoDB node module to add, modify and delete data in a MongoDB collection using a book databases as an example.
 author: louise-findlay

--- a/articles/writing-with-the-rust-language/index.md
+++ b/articles/writing-with-the-rust-language/index.md
@@ -2,7 +2,7 @@
 layout: engineering-education
 status: publish
 published: true
-slug: writing-with-the-rust-language
+url: /engineering-education/writing-with-the-rust-language/
 title: Writing Good Code with the Rust Language
 description: How Rust forces you to write good code which, in turn, eliminates all possibility of undefined behavior that can cause segfaults.
 author: zack-jorquera

--- a/authors/_index.md
+++ b/authors/_index.md
@@ -1,7 +1,5 @@
 ---
-title: 🙋 Authors
+title: EngEd Contributors
 description: The people behind Engineering Education
 type: authors
 ---
-
-Hello 🚀

--- a/authors/_index.md
+++ b/authors/_index.md
@@ -1,0 +1,7 @@
+---
+title: 🙋 Authors
+description: The people behind Engineering Education
+type: authors
+---
+
+Hello 🚀

--- a/authors/aakash-rawal/index.md
+++ b/authors/aakash-rawal/index.md
@@ -1,4 +1,4 @@
 ---
-name: Aakash Rawal
+title: Aakash Rawal
 ---
 Aakash Rawal is a first-year graduate student pursuing a Masters in Technology, Cybersecurity and Policy at the University of Colorado Boulder. He is interested in Network Automation, DevOps and Network Security.

--- a/authors/aakash-rawal/index.md
+++ b/authors/aakash-rawal/index.md
@@ -1,5 +1,5 @@
 ---
 title: Aakash Rawal
-type: author
+type: engineering-education/author
 ---
 Aakash Rawal is a first-year graduate student pursuing a Masters in Technology, Cybersecurity and Policy at the University of Colorado Boulder. He is interested in Network Automation, DevOps and Network Security.

--- a/authors/aakash-rawal/index.md
+++ b/authors/aakash-rawal/index.md
@@ -1,4 +1,5 @@
 ---
 title: Aakash Rawal
+type: author
 ---
 Aakash Rawal is a first-year graduate student pursuing a Masters in Technology, Cybersecurity and Policy at the University of Colorado Boulder. He is interested in Network Automation, DevOps and Network Security.

--- a/authors/abel-mathew/index.md
+++ b/authors/abel-mathew/index.md
@@ -1,6 +1,6 @@
 ---
 title: Abel Mathew
-type: author
+type: engineering-education/author
 linkedin: https://www.linkedin.com/in/designrknight/
 github: https://github.com/DesignrKnight
 ---

--- a/authors/abel-mathew/index.md
+++ b/authors/abel-mathew/index.md
@@ -1,5 +1,5 @@
 ---
-name: Abel Mathew
+title: Abel Mathew
 linkedin: https://www.linkedin.com/in/designrknight/
 github: https://github.com/DesignrKnight
 ---

--- a/authors/abel-mathew/index.md
+++ b/authors/abel-mathew/index.md
@@ -1,5 +1,6 @@
 ---
 title: Abel Mathew
+type: author
 linkedin: https://www.linkedin.com/in/designrknight/
 github: https://github.com/DesignrKnight
 ---

--- a/authors/ada-lovelace/index.md
+++ b/authors/ada-lovelace/index.md
@@ -1,5 +1,5 @@
 ---
-name: Ada Lovelace
+title: Ada Lovelace
 twitter: https://twitter.com/AdaLovelaceInst
 website: https://en.wikipedia.org/wiki/Ada_Lovelace
 github: https://github.com/ada.lovelace

--- a/authors/ada-lovelace/index.md
+++ b/authors/ada-lovelace/index.md
@@ -1,6 +1,6 @@
 ---
 title: Ada Lovelace
-type: author
+type: engineering-education/author
 twitter: https://twitter.com/AdaLovelaceInst
 website: https://en.wikipedia.org/wiki/Ada_Lovelace
 github: https://github.com/ada.lovelace

--- a/authors/ada-lovelace/index.md
+++ b/authors/ada-lovelace/index.md
@@ -1,5 +1,6 @@
 ---
 title: Ada Lovelace
+type: author
 twitter: https://twitter.com/AdaLovelaceInst
 website: https://en.wikipedia.org/wiki/Ada_Lovelace
 github: https://github.com/ada.lovelace

--- a/authors/adith-bharadwaj/index.md
+++ b/authors/adith-bharadwaj/index.md
@@ -1,5 +1,6 @@
 ---
 title: Adith Bharadwaj
+type: author
 linkedin: https://www.linkedin.com/in/adith-bharadwaj-07a586160/
 ---
 Adith Bharadwaj is a senior at the National Institute of Engineering (NIE) and a Software Engineer Intern at Cisco - India. Adith has a keen interest in solving challenging problems and is a data science and machine learning enthusiast. When he’s not coding, he loves drawing, working out, and watching great TV shows, movies or anime.

--- a/authors/adith-bharadwaj/index.md
+++ b/authors/adith-bharadwaj/index.md
@@ -1,5 +1,5 @@
 ---
-name: Adith Bharadwaj
+title: Adith Bharadwaj
 linkedin: https://www.linkedin.com/in/adith-bharadwaj-07a586160/
 ---
 Adith Bharadwaj is a senior at the National Institute of Engineering (NIE) and a Software Engineer Intern at Cisco - India. Adith has a keen interest in solving challenging problems and is a data science and machine learning enthusiast. When he’s not coding, he loves drawing, working out, and watching great TV shows, movies or anime.

--- a/authors/adith-bharadwaj/index.md
+++ b/authors/adith-bharadwaj/index.md
@@ -1,6 +1,6 @@
 ---
 title: Adith Bharadwaj
-type: author
+type: engineering-education/author
 linkedin: https://www.linkedin.com/in/adith-bharadwaj-07a586160/
 ---
 Adith Bharadwaj is a senior at the National Institute of Engineering (NIE) and a Software Engineer Intern at Cisco - India. Adith has a keen interest in solving challenging problems and is a data science and machine learning enthusiast. When he’s not coding, he loves drawing, working out, and watching great TV shows, movies or anime.

--- a/authors/aditi-jayakumar/index.md
+++ b/authors/aditi-jayakumar/index.md
@@ -1,4 +1,4 @@
 ---
-name: Aditi Jayakumar
+title: Aditi Jayakumar
 ---
 Aditi Jayakumar is an undergraduate student at JSS Science and Technology University. She is an aspiring medical biotechnologist exploring beyond boundaries. Her advocations include reading and travelling. 

--- a/authors/aditi-jayakumar/index.md
+++ b/authors/aditi-jayakumar/index.md
@@ -1,5 +1,5 @@
 ---
 title: Aditi Jayakumar
-type: author
+type: engineering-education/author
 ---
 Aditi Jayakumar is an undergraduate student at JSS Science and Technology University. She is an aspiring medical biotechnologist exploring beyond boundaries. Her advocations include reading and travelling. 

--- a/authors/aditi-jayakumar/index.md
+++ b/authors/aditi-jayakumar/index.md
@@ -1,4 +1,5 @@
 ---
 title: Aditi Jayakumar
+type: author
 ---
 Aditi Jayakumar is an undergraduate student at JSS Science and Technology University. She is an aspiring medical biotechnologist exploring beyond boundaries. Her advocations include reading and travelling. 

--- a/authors/adrian-murage/index.md
+++ b/authors/adrian-murage/index.md
@@ -1,4 +1,5 @@
 ---
 title: Adrian Murage
+type: author
 ---
 Adrian is an undergraduate student pursuing a degree in Applied Computer Technology. Adrian loves technical writing, contributing to open source projects, and involving himself in the creation of learning material for aspiring software engineers.

--- a/authors/adrian-murage/index.md
+++ b/authors/adrian-murage/index.md
@@ -1,4 +1,4 @@
 ---
-name: Adrian Murage
+title: Adrian Murage
 ---
 Adrian is an undergraduate student pursuing a degree in Applied Computer Technology. Adrian loves technical writing, contributing to open source projects, and involving himself in the creation of learning material for aspiring software engineers.

--- a/authors/adrian-murage/index.md
+++ b/authors/adrian-murage/index.md
@@ -1,5 +1,5 @@
 ---
 title: Adrian Murage
-type: author
+type: engineering-education/author
 ---
 Adrian is an undergraduate student pursuing a degree in Applied Computer Technology. Adrian loves technical writing, contributing to open source projects, and involving himself in the creation of learning material for aspiring software engineers.

--- a/authors/aman-saxena/index.md
+++ b/authors/aman-saxena/index.md
@@ -1,5 +1,6 @@
 ---
 title: Aman Saxena
+type: author
 linkedin: https://www.linkedin.com/in/amansaxena333
 ---
  Aman Saxena is pursuing a degree in Computer Science. He has a keen interest in Competitive Programming & Web Development. He is fond of playing Cricket & solving Big-O complexities. When he’s not glued to a computer screen, he is likely exploring the mighty Universe. For any query or a fruitful discussion, you may connect with him on LinkedIn.

--- a/authors/aman-saxena/index.md
+++ b/authors/aman-saxena/index.md
@@ -1,5 +1,5 @@
 ---
-name: Aman Saxena
+title: Aman Saxena
 linkedin: https://www.linkedin.com/in/amansaxena333
 ---
  Aman Saxena is pursuing a degree in Computer Science. He has a keen interest in Competitive Programming & Web Development. He is fond of playing Cricket & solving Big-O complexities. When he’s not glued to a computer screen, he is likely exploring the mighty Universe. For any query or a fruitful discussion, you may connect with him on LinkedIn.

--- a/authors/aman-saxena/index.md
+++ b/authors/aman-saxena/index.md
@@ -1,6 +1,6 @@
 ---
 title: Aman Saxena
-type: author
+type: engineering-education/author
 linkedin: https://www.linkedin.com/in/amansaxena333
 ---
  Aman Saxena is pursuing a degree in Computer Science. He has a keen interest in Competitive Programming & Web Development. He is fond of playing Cricket & solving Big-O complexities. When he’s not glued to a computer screen, he is likely exploring the mighty Universe. For any query or a fruitful discussion, you may connect with him on LinkedIn.

--- a/authors/bora-basyildiz/index.md
+++ b/authors/bora-basyildiz/index.md
@@ -1,4 +1,5 @@
 ---
 title: Bora Basyildiz
+type: author
 ---
 Bora Basyildiz is a sophomore at Colorado School of Mines where he is majoring in Computer Science and Mathematics with a minor in Physics and liberal arts with the McBride Program. He is currently a contributor for Section's Engineering Education Content Program and is also an experienced jazz pianist, even teaching piano for eight years. His heavy teaching experience has led him to work with many organizations such as Bravo! Vail and Vail Jazz, leading to strong skills in team management, communications, and planning.

--- a/authors/bora-basyildiz/index.md
+++ b/authors/bora-basyildiz/index.md
@@ -1,5 +1,5 @@
 ---
 title: Bora Basyildiz
-type: author
+type: engineering-education/author
 ---
 Bora Basyildiz is a sophomore at Colorado School of Mines where he is majoring in Computer Science and Mathematics with a minor in Physics and liberal arts with the McBride Program. He is currently a contributor for Section's Engineering Education Content Program and is also an experienced jazz pianist, even teaching piano for eight years. His heavy teaching experience has led him to work with many organizations such as Bravo! Vail and Vail Jazz, leading to strong skills in team management, communications, and planning.

--- a/authors/bora-basyildiz/index.md
+++ b/authors/bora-basyildiz/index.md
@@ -1,4 +1,4 @@
 ---
-name: Bora Basyildiz
+title: Bora Basyildiz
 ---
 Bora Basyildiz is a sophomore at Colorado School of Mines where he is majoring in Computer Science and Mathematics with a minor in Physics and liberal arts with the McBride Program. He is currently a contributor for Section's Engineering Education Content Program and is also an experienced jazz pianist, even teaching piano for eight years. His heavy teaching experience has led him to work with many organizations such as Bravo! Vail and Vail Jazz, leading to strong skills in team management, communications, and planning.

--- a/authors/dominic-nshimba/index.md
+++ b/authors/dominic-nshimba/index.md
@@ -1,4 +1,4 @@
 ---
-name: Dominic Nshimba
+title: Dominic Nshimba
 ---
 Dominic Nshimba is a Web Developer at All1Zed and currently a Hack Club Facilitator for HackClub in Zambia. He is pursuing a degree in computer science and applied mathematics. Dominic's key interest lies in systems programming.

--- a/authors/dominic-nshimba/index.md
+++ b/authors/dominic-nshimba/index.md
@@ -1,4 +1,5 @@
 ---
 title: Dominic Nshimba
+type: author
 ---
 Dominic Nshimba is a Web Developer at All1Zed and currently a Hack Club Facilitator for HackClub in Zambia. He is pursuing a degree in computer science and applied mathematics. Dominic's key interest lies in systems programming.

--- a/authors/dominic-nshimba/index.md
+++ b/authors/dominic-nshimba/index.md
@@ -1,5 +1,5 @@
 ---
 title: Dominic Nshimba
-type: author
+type: engineering-education/author
 ---
 Dominic Nshimba is a Web Developer at All1Zed and currently a Hack Club Facilitator for HackClub in Zambia. He is pursuing a degree in computer science and applied mathematics. Dominic's key interest lies in systems programming.

--- a/authors/earl-potters/index.md
+++ b/authors/earl-potters/index.md
@@ -1,4 +1,5 @@
 ---
 title: Earl Potters
+type: author
 ---
 Earl is a Junior at CU Boulder pursuing a degree in Computer Science. Earl’s passions are robotics and rugby. He is the founder of RoboBoat at CU Boulder, a robotics club that focus on designing and building ASV(Autonomous Surface Vehicles) for the annual Roboboat International Competition.

--- a/authors/earl-potters/index.md
+++ b/authors/earl-potters/index.md
@@ -1,4 +1,4 @@
 ---
-name: Earl Potters
+title: Earl Potters
 ---
 Earl is a Junior at CU Boulder pursuing a degree in Computer Science. Earl’s passions are robotics and rugby. He is the founder of RoboBoat at CU Boulder, a robotics club that focus on designing and building ASV(Autonomous Surface Vehicles) for the annual Roboboat International Competition.

--- a/authors/earl-potters/index.md
+++ b/authors/earl-potters/index.md
@@ -1,5 +1,5 @@
 ---
 title: Earl Potters
-type: author
+type: engineering-education/author
 ---
 Earl is a Junior at CU Boulder pursuing a degree in Computer Science. Earl’s passions are robotics and rugby. He is the founder of RoboBoat at CU Boulder, a robotics club that focus on designing and building ASV(Autonomous Surface Vehicles) for the annual Roboboat International Competition.

--- a/authors/francisca-adekanye/index.md
+++ b/authors/francisca-adekanye/index.md
@@ -1,4 +1,5 @@
 ---
 title: Francisca
+type: author
 ---
 Francisca is an undergraduate student pursuing a degree in Computer Engineering. Cisca loves technical writing, contributing to open source projects, and also involving herself in tech communities.

--- a/authors/francisca-adekanye/index.md
+++ b/authors/francisca-adekanye/index.md
@@ -1,5 +1,5 @@
 ---
 title: Francisca
-type: author
+type: engineering-education/author
 ---
 Francisca is an undergraduate student pursuing a degree in Computer Engineering. Cisca loves technical writing, contributing to open source projects, and also involving herself in tech communities.

--- a/authors/francisca-adekanye/index.md
+++ b/authors/francisca-adekanye/index.md
@@ -1,4 +1,4 @@
 ---
-name: Francisca
+title: Francisca
 ---
 Francisca is an undergraduate student pursuing a degree in Computer Engineering. Cisca loves technical writing, contributing to open source projects, and also involving herself in tech communities.

--- a/authors/gregory-manley/index.md
+++ b/authors/gregory-manley/index.md
@@ -1,4 +1,4 @@
 ---
-name: Gregory Manley
+title: Gregory Manley
 ---
 Gregory Manley is a sophomore at Colorado School of Mines where he is majoring in Computer Science with a minor in Mining Engineering. He is  the owner of iTech News and a contributor for Section's Engineering Education Content Program. His management of iTech News has led him to work with many brands on writing technology focus articles.

--- a/authors/gregory-manley/index.md
+++ b/authors/gregory-manley/index.md
@@ -1,5 +1,5 @@
 ---
 title: Gregory Manley
-type: author
+type: engineering-education/author
 ---
 Gregory Manley is a sophomore at Colorado School of Mines where he is majoring in Computer Science with a minor in Mining Engineering. He is  the owner of iTech News and a contributor for Section's Engineering Education Content Program. His management of iTech News has led him to work with many brands on writing technology focus articles.

--- a/authors/gregory-manley/index.md
+++ b/authors/gregory-manley/index.md
@@ -1,4 +1,5 @@
 ---
 title: Gregory Manley
+type: author
 ---
 Gregory Manley is a sophomore at Colorado School of Mines where he is majoring in Computer Science with a minor in Mining Engineering. He is  the owner of iTech News and a contributor for Section's Engineering Education Content Program. His management of iTech News has led him to work with many brands on writing technology focus articles.

--- a/authors/ian-jorquera/index.md
+++ b/authors/ian-jorquera/index.md
@@ -1,4 +1,5 @@
 ---
 title: Ian Jorquera
+type: author
 ---
 Ian Jorquera is an undergraduate student at the University of Colorado Boulder pursuing a degree in Computer Science. Ian is particularly interested in mathematics and algorithms. In his free time, Ian enjoys skiing and whitewater kayaking.

--- a/authors/ian-jorquera/index.md
+++ b/authors/ian-jorquera/index.md
@@ -1,4 +1,4 @@
 ---
-name: Ian Jorquera
+title: Ian Jorquera
 ---
 Ian Jorquera is an undergraduate student at the University of Colorado Boulder pursuing a degree in Computer Science. Ian is particularly interested in mathematics and algorithms. In his free time, Ian enjoys skiing and whitewater kayaking.

--- a/authors/ian-jorquera/index.md
+++ b/authors/ian-jorquera/index.md
@@ -1,5 +1,5 @@
 ---
 title: Ian Jorquera
-type: author
+type: engineering-education/author
 ---
 Ian Jorquera is an undergraduate student at the University of Colorado Boulder pursuing a degree in Computer Science. Ian is particularly interested in mathematics and algorithms. In his free time, Ian enjoys skiing and whitewater kayaking.

--- a/authors/ivan-santos/index.md
+++ b/authors/ivan-santos/index.md
@@ -1,5 +1,5 @@
 ---
 title: Ivan Santos
-type: author
+type: engineering-education/author
 ---
 Ivan Santos is currently a computer science student at the Colorado School of Mines. He originates from the rural parts of Aguascalientes, Mexico, but grew up in Denver, CO where he remains today. He has developed a special relationship with numbers throughout his academic experience, realizing his favorite application for numbers, logic, and math is computer science. Aside from his studies, he has always had a strong passion for soccer, and his favorite teams vary across countries - FC Barcelona from Spain and Club America from Mexico hold the biggest place in his heart.

--- a/authors/ivan-santos/index.md
+++ b/authors/ivan-santos/index.md
@@ -1,4 +1,5 @@
 ---
 title: Ivan Santos
+type: author
 ---
 Ivan Santos is currently a computer science student at the Colorado School of Mines. He originates from the rural parts of Aguascalientes, Mexico, but grew up in Denver, CO where he remains today. He has developed a special relationship with numbers throughout his academic experience, realizing his favorite application for numbers, logic, and math is computer science. Aside from his studies, he has always had a strong passion for soccer, and his favorite teams vary across countries - FC Barcelona from Spain and Club America from Mexico hold the biggest place in his heart.

--- a/authors/ivan-santos/index.md
+++ b/authors/ivan-santos/index.md
@@ -1,4 +1,4 @@
 ---
-name: Ivan Santos
+title: Ivan Santos
 ---
 Ivan Santos is currently a computer science student at the Colorado School of Mines. He originates from the rural parts of Aguascalientes, Mexico, but grew up in Denver, CO where he remains today. He has developed a special relationship with numbers throughout his academic experience, realizing his favorite application for numbers, logic, and math is computer science. Aside from his studies, he has always had a strong passion for soccer, and his favorite teams vary across countries - FC Barcelona from Spain and Club America from Mexico hold the biggest place in his heart.

--- a/authors/jesus-nunez/index.md
+++ b/authors/jesus-nunez/index.md
@@ -1,4 +1,5 @@
 ---
 title: Jesus Nunez
+type: author
 ---
 Jesus Nunez is a Sophomore at Colorado School of Mines where he is getting his Computer Science degree with a focus in Computer Engineering. He is an avid Linux user and Vice President to the Linux Users Group.

--- a/authors/jesus-nunez/index.md
+++ b/authors/jesus-nunez/index.md
@@ -1,4 +1,4 @@
 ---
-name: Jesus Nunez
+title: Jesus Nunez
 ---
 Jesus Nunez is a Sophomore at Colorado School of Mines where he is getting his Computer Science degree with a focus in Computer Engineering. He is an avid Linux user and Vice President to the Linux Users Group.

--- a/authors/jesus-nunez/index.md
+++ b/authors/jesus-nunez/index.md
@@ -1,5 +1,5 @@
 ---
 title: Jesus Nunez
-type: author
+type: engineering-education/author
 ---
 Jesus Nunez is a Sophomore at Colorado School of Mines where he is getting his Computer Science degree with a focus in Computer Engineering. He is an avid Linux user and Vice President to the Linux Users Group.

--- a/authors/jethro-magaji/index.md
+++ b/authors/jethro-magaji/index.md
@@ -1,4 +1,4 @@
 ---
-name: Jethro Magaji
+title: Jethro Magaji
 ---
 Jethro Magaji is a student at Kaduna State University With Frontend Development and UI/UX Design skills. He is passionate and enthusiastic about Blockchain technology and also uses creative thinking to solve business problems using a user-centered approach. He spends most of his time either learning a new skill or teaching others what he loves doing best.

--- a/authors/jethro-magaji/index.md
+++ b/authors/jethro-magaji/index.md
@@ -1,5 +1,5 @@
 ---
 title: Jethro Magaji
-type: author
+type: engineering-education/author
 ---
 Jethro Magaji is a student at Kaduna State University With Frontend Development and UI/UX Design skills. He is passionate and enthusiastic about Blockchain technology and also uses creative thinking to solve business problems using a user-centered approach. He spends most of his time either learning a new skill or teaching others what he loves doing best.

--- a/authors/jethro-magaji/index.md
+++ b/authors/jethro-magaji/index.md
@@ -1,4 +1,5 @@
 ---
 title: Jethro Magaji
+type: author
 ---
 Jethro Magaji is a student at Kaduna State University With Frontend Development and UI/UX Design skills. He is passionate and enthusiastic about Blockchain technology and also uses creative thinking to solve business problems using a user-centered approach. He spends most of his time either learning a new skill or teaching others what he loves doing best.

--- a/authors/jonathan-popova-jones/index.md
+++ b/authors/jonathan-popova-jones/index.md
@@ -1,5 +1,5 @@
 ---
 title: Jonathan Popova-Jones
-type: author
+type: engineering-education/author
 ---
 Jonathan Popova-Jones is pursuing a computer science degree at the Colorado School of Mines. He is originally from Boulder, Colorado, but has been living in the Washington D.C. area for the past 10 years. When not busy with schoolwork, he enjoys fishing, traveling, and working on coding projects. "I’m glad to be a part of this program since it gives me the opportunity to expand my knowledge of computer science topics related to Section as well as learn more about the computer science industry.

--- a/authors/jonathan-popova-jones/index.md
+++ b/authors/jonathan-popova-jones/index.md
@@ -1,4 +1,5 @@
 ---
 title: Jonathan Popova-Jones
+type: author
 ---
 Jonathan Popova-Jones is pursuing a computer science degree at the Colorado School of Mines. He is originally from Boulder, Colorado, but has been living in the Washington D.C. area for the past 10 years. When not busy with schoolwork, he enjoys fishing, traveling, and working on coding projects. "I’m glad to be a part of this program since it gives me the opportunity to expand my knowledge of computer science topics related to Section as well as learn more about the computer science industry.

--- a/authors/jonathan-popova-jones/index.md
+++ b/authors/jonathan-popova-jones/index.md
@@ -1,4 +1,4 @@
 ---
-name: Jonathan Popova-Jones
+title: Jonathan Popova-Jones
 ---
 Jonathan Popova-Jones is pursuing a computer science degree at the Colorado School of Mines. He is originally from Boulder, Colorado, but has been living in the Washington D.C. area for the past 10 years. When not busy with schoolwork, he enjoys fishing, traveling, and working on coding projects. "I’m glad to be a part of this program since it gives me the opportunity to expand my knowledge of computer science topics related to Section as well as learn more about the computer science industry.

--- a/authors/judy-nduati/index.md
+++ b/authors/judy-nduati/index.md
@@ -1,4 +1,4 @@
 ---
-name: judy-nduati
+title: judy-nduati
 ---
 Judy is a student pursuing Business Information Technology. She is passionate, self-motivated, and a solution-oriented technology enthusiast. She is also a front-end web developer and a web designer. She loves technical writing and contributing to open-source projects.

--- a/authors/judy-nduati/index.md
+++ b/authors/judy-nduati/index.md
@@ -1,5 +1,5 @@
 ---
 title: judy-nduati
-type: author
+type: engineering-education/author
 ---
 Judy is a student pursuing Business Information Technology. She is passionate, self-motivated, and a solution-oriented technology enthusiast. She is also a front-end web developer and a web designer. She loves technical writing and contributing to open-source projects.

--- a/authors/judy-nduati/index.md
+++ b/authors/judy-nduati/index.md
@@ -1,4 +1,5 @@
 ---
 title: judy-nduati
+type: author
 ---
 Judy is a student pursuing Business Information Technology. She is passionate, self-motivated, and a solution-oriented technology enthusiast. She is also a front-end web developer and a web designer. She loves technical writing and contributing to open-source projects.

--- a/authors/justin-osborne/index.md
+++ b/authors/justin-osborne/index.md
@@ -1,4 +1,5 @@
 ---
 title: Justin Osborne
+type: author
 ---
 Justin Osborne is a Senior at Wichita State University pursuing a degree in Mechanical Engineering. Justin’s passions are robotics and learning new subjects. He is Event Coordinator for the SAMPE chapter at Wichita State, a club that focuses on teaching and networking with professionals around manufacturing practices and techniques happening in the industry.

--- a/authors/justin-osborne/index.md
+++ b/authors/justin-osborne/index.md
@@ -1,4 +1,4 @@
 ---
-name: Justin Osborne
+title: Justin Osborne
 ---
 Justin Osborne is a Senior at Wichita State University pursuing a degree in Mechanical Engineering. Justin’s passions are robotics and learning new subjects. He is Event Coordinator for the SAMPE chapter at Wichita State, a club that focuses on teaching and networking with professionals around manufacturing practices and techniques happening in the industry.

--- a/authors/justin-osborne/index.md
+++ b/authors/justin-osborne/index.md
@@ -1,5 +1,5 @@
 ---
 title: Justin Osborne
-type: author
+type: engineering-education/author
 ---
 Justin Osborne is a Senior at Wichita State University pursuing a degree in Mechanical Engineering. Justin’s passions are robotics and learning new subjects. He is Event Coordinator for the SAMPE chapter at Wichita State, a club that focuses on teaching and networking with professionals around manufacturing practices and techniques happening in the industry.

--- a/authors/kanishkvardhan-a-n/index.md
+++ b/authors/kanishkvardhan-a-n/index.md
@@ -1,5 +1,5 @@
 ---
 title: Kanishkvardhan A N
-type: author
+type: engineering-education/author
 ---
 Kanishkvardhan A N is a sophomore at SDM College of Engineering and Technology pursuing his B.E in Information Science and Engineering. Apart from coding, he is ardent about exploring stellar space and understanding astronomy. In his leisure, he likes to play the guitar and write short stories.

--- a/authors/kanishkvardhan-a-n/index.md
+++ b/authors/kanishkvardhan-a-n/index.md
@@ -1,4 +1,4 @@
 ---
-name: Kanishkvardhan A N
+title: Kanishkvardhan A N
 ---
 Kanishkvardhan A N is a sophomore at SDM College of Engineering and Technology pursuing his B.E in Information Science and Engineering. Apart from coding, he is ardent about exploring stellar space and understanding astronomy. In his leisure, he likes to play the guitar and write short stories.

--- a/authors/kanishkvardhan-a-n/index.md
+++ b/authors/kanishkvardhan-a-n/index.md
@@ -1,4 +1,5 @@
 ---
 title: Kanishkvardhan A N
+type: author
 ---
 Kanishkvardhan A N is a sophomore at SDM College of Engineering and Technology pursuing his B.E in Information Science and Engineering. Apart from coding, he is ardent about exploring stellar space and understanding astronomy. In his leisure, he likes to play the guitar and write short stories.

--- a/authors/keerthi-v/index.md
+++ b/authors/keerthi-v/index.md
@@ -1,4 +1,4 @@
 ---
-name: Keerthi V
+title: Keerthi V
 ---
 Keerthi V is a senior at JSS Science and Technology University and a Data Engineering Intern at redBus. Her key interests include Data Science and Web Development. When she's not coding, she's probably running or baking pizzas.

--- a/authors/keerthi-v/index.md
+++ b/authors/keerthi-v/index.md
@@ -1,4 +1,5 @@
 ---
 title: Keerthi V
+type: author
 ---
 Keerthi V is a senior at JSS Science and Technology University and a Data Engineering Intern at redBus. Her key interests include Data Science and Web Development. When she's not coding, she's probably running or baking pizzas.

--- a/authors/keerthi-v/index.md
+++ b/authors/keerthi-v/index.md
@@ -1,5 +1,5 @@
 ---
 title: Keerthi V
-type: author
+type: engineering-education/author
 ---
 Keerthi V is a senior at JSS Science and Technology University and a Data Engineering Intern at redBus. Her key interests include Data Science and Web Development. When she's not coding, she's probably running or baking pizzas.

--- a/authors/lalithnarayan-c/index.md
+++ b/authors/lalithnarayan-c/index.md
@@ -1,5 +1,6 @@
 ---
-name: Lalithnarayan c
+title: Lalithnarayan c
 linkedin: https://www.linkedin.com/in/lalith-narayan-27a89a1b/
 ---
-Lalithnaryan C is an ambitious and creative engineer pursuing his final year of engineering at PES University, Bangalore. He is passionate about building tech products that inspire and make space for human creativity to flourish. On a quest to understand the infinite intelligence through technology, philosophy, and meditation.  
+
+Lalithnaryan C is an ambitious and creative engineer pursuing his final year of engineering at PES University, Bangalore. He is passionate about building tech products that inspire and make space for human creativity to flourish. On a quest to understand the infinite intelligence through technology, philosophy, and meditation.

--- a/authors/lalithnarayan-c/index.md
+++ b/authors/lalithnarayan-c/index.md
@@ -1,5 +1,6 @@
 ---
 title: Lalithnarayan c
+type: author
 linkedin: https://www.linkedin.com/in/lalith-narayan-27a89a1b/
 ---
 

--- a/authors/lalithnarayan-c/index.md
+++ b/authors/lalithnarayan-c/index.md
@@ -1,6 +1,6 @@
 ---
 title: Lalithnarayan c
-type: author
+type: engineering-education/author
 linkedin: https://www.linkedin.com/in/lalith-narayan-27a89a1b/
 ---
 

--- a/authors/linus-muema/index.md
+++ b/authors/linus-muema/index.md
@@ -1,5 +1,5 @@
 ---
 title: Linus Muema
-type: author
+type: engineering-education/author
 ---
 Linus Muema is a first-year undergraduate student who develops Kotlin and Javascript applications. Linus has a great passion for writing code, trying out new programming paradigms, and is always ready to help other developers.

--- a/authors/linus-muema/index.md
+++ b/authors/linus-muema/index.md
@@ -1,4 +1,4 @@
 ---
-name: Linus Muema
+title: Linus Muema
 ---
 Linus Muema is a first-year undergraduate student who develops Kotlin and Javascript applications. Linus has a great passion for writing code, trying out new programming paradigms, and is always ready to help other developers.

--- a/authors/linus-muema/index.md
+++ b/authors/linus-muema/index.md
@@ -1,4 +1,5 @@
 ---
 title: Linus Muema
+type: author
 ---
 Linus Muema is a first-year undergraduate student who develops Kotlin and Javascript applications. Linus has a great passion for writing code, trying out new programming paradigms, and is always ready to help other developers.

--- a/authors/louise-findlay/index.md
+++ b/authors/louise-findlay/index.md
@@ -1,5 +1,6 @@
 ---
 title: Louise Findlay
+type: author
 twitter: https://twitter.com/louisefindlay23
 website: https://louisefindlay.com/
 ---

--- a/authors/louise-findlay/index.md
+++ b/authors/louise-findlay/index.md
@@ -1,6 +1,6 @@
 ---
 title: Louise Findlay
-type: author
+type: engineering-education/author
 twitter: https://twitter.com/louisefindlay23
 website: https://louisefindlay.com/
 ---

--- a/authors/louise-findlay/index.md
+++ b/authors/louise-findlay/index.md
@@ -1,5 +1,5 @@
 ---
-name: Louise Findlay
+title: Louise Findlay
 twitter: https://twitter.com/louisefindlay23
 website: https://louisefindlay.com/
 ---

--- a/authors/lucas-gompou/index.md
+++ b/authors/lucas-gompou/index.md
@@ -1,4 +1,5 @@
 ---
 title: Lucas Gompou
+type: author
 ---
 Lucas Gompou is a sophomore CS undergraduate at Scottsdale Community College. He is a self-taught full-stack developer very keen on learning about artificial Intelligence. He enjoys attending hackathons and tutoring newcomers at his college. In his spare time,  you can find him doing some community service or cruising around the city with his longboard.

--- a/authors/lucas-gompou/index.md
+++ b/authors/lucas-gompou/index.md
@@ -1,4 +1,4 @@
 ---
-name: Lucas Gompou
+title: Lucas Gompou
 ---
 Lucas Gompou is a sophomore CS undergraduate at Scottsdale Community College. He is a self-taught full-stack developer very keen on learning about artificial Intelligence. He enjoys attending hackathons and tutoring newcomers at his college. In his spare time,  you can find him doing some community service or cruising around the city with his longboard.

--- a/authors/lucas-gompou/index.md
+++ b/authors/lucas-gompou/index.md
@@ -1,5 +1,5 @@
 ---
 title: Lucas Gompou
-type: author
+type: engineering-education/author
 ---
 Lucas Gompou is a sophomore CS undergraduate at Scottsdale Community College. He is a self-taught full-stack developer very keen on learning about artificial Intelligence. He enjoys attending hackathons and tutoring newcomers at his college. In his spare time,  you can find him doing some community service or cruising around the city with his longboard.

--- a/authors/michael-zanoff/index.md
+++ b/authors/michael-zanoff/index.md
@@ -1,4 +1,4 @@
 ---
-name: Michael Zanoff
+title: Michael Zanoff
 ---
 Michael Zanoff is a freshman at Colorado School of Mines. His passion for the design process and robotics has led him to pursue a degree in Mechanical Engineering. He enjoys keeping up with new technology and learning about the world around him.

--- a/authors/michael-zanoff/index.md
+++ b/authors/michael-zanoff/index.md
@@ -1,4 +1,5 @@
 ---
 title: Michael Zanoff
+type: author
 ---
 Michael Zanoff is a freshman at Colorado School of Mines. His passion for the design process and robotics has led him to pursue a degree in Mechanical Engineering. He enjoys keeping up with new technology and learning about the world around him.

--- a/authors/michael-zanoff/index.md
+++ b/authors/michael-zanoff/index.md
@@ -1,5 +1,5 @@
 ---
 title: Michael Zanoff
-type: author
+type: engineering-education/author
 ---
 Michael Zanoff is a freshman at Colorado School of Mines. His passion for the design process and robotics has led him to pursue a degree in Mechanical Engineering. He enjoys keeping up with new technology and learning about the world around him.

--- a/authors/mike-white/index.md
+++ b/authors/mike-white/index.md
@@ -1,4 +1,5 @@
 ---
 title: Mike White
+type: author
 ---
 Mike White is a second-year Computer Science student at the Rochester Institute of Technology. His interests are technology, philosophy, culture, music, and effective altruism. Mike has a blog about technology and philosophy. If he isn’t doing any of that, then he’s probably either playing a Sherlock Holmes video game or watching YouTube.

--- a/authors/mike-white/index.md
+++ b/authors/mike-white/index.md
@@ -1,5 +1,5 @@
 ---
 title: Mike White
-type: author
+type: engineering-education/author
 ---
 Mike White is a second-year Computer Science student at the Rochester Institute of Technology. His interests are technology, philosophy, culture, music, and effective altruism. Mike has a blog about technology and philosophy. If he isn’t doing any of that, then he’s probably either playing a Sherlock Holmes video game or watching YouTube.

--- a/authors/mike-white/index.md
+++ b/authors/mike-white/index.md
@@ -1,4 +1,4 @@
 ---
-name: Mike White
+title: Mike White
 ---
 Mike White is a second-year Computer Science student at the Rochester Institute of Technology. His interests are technology, philosophy, culture, music, and effective altruism. Mike has a blog about technology and philosophy. If he isn’t doing any of that, then he’s probably either playing a Sherlock Holmes video game or watching YouTube.

--- a/authors/nadiv-gold-edelstein/index.md
+++ b/authors/nadiv-gold-edelstein/index.md
@@ -1,4 +1,5 @@
 ---
 title: Nadiv Gold
+type: author
 ---
 Nadiv Gold Edelstein is a sophomore at University of Colorado at Boulder. He enjoys full stack development, teaching computer science, and being strongly opinionated about code.

--- a/authors/nadiv-gold-edelstein/index.md
+++ b/authors/nadiv-gold-edelstein/index.md
@@ -1,4 +1,4 @@
 ---
-name: Nadiv Gold
+title: Nadiv Gold
 ---
 Nadiv Gold Edelstein is a sophomore at University of Colorado at Boulder. He enjoys full stack development, teaching computer science, and being strongly opinionated about code.

--- a/authors/nadiv-gold-edelstein/index.md
+++ b/authors/nadiv-gold-edelstein/index.md
@@ -1,5 +1,5 @@
 ---
 title: Nadiv Gold
-type: author
+type: engineering-education/author
 ---
 Nadiv Gold Edelstein is a sophomore at University of Colorado at Boulder. He enjoys full stack development, teaching computer science, and being strongly opinionated about code.

--- a/authors/parampreet-singh/index.md
+++ b/authors/parampreet-singh/index.md
@@ -1,6 +1,6 @@
 ---
 title: Parampreet Singh
-type: author
+type: engineering-education/author
 ---
 Parampreet Singh is a Computer Science Undergraduate Student at Ohio Wesleyan University. He really likes working with new technologies and wants to be entrepreneur with the motto of helping the world be a better place.
 He is the founder of the website studentpath.co, where students can find free resources to learn anything they want. The website is growing period to include newest features in order to help the students in every possible way.

--- a/authors/parampreet-singh/index.md
+++ b/authors/parampreet-singh/index.md
@@ -1,5 +1,5 @@
 ---
-name: Parampreet Singh
+title: Parampreet Singh
 ---
 Parampreet Singh is a Computer Science Undergraduate Student at Ohio Wesleyan University. He really likes working with new technologies and wants to be entrepreneur with the motto of helping the world be a better place.
 He is the founder of the website studentpath.co, where students can find free resources to learn anything they want. The website is growing period to include newest features in order to help the students in every possible way.

--- a/authors/parampreet-singh/index.md
+++ b/authors/parampreet-singh/index.md
@@ -1,5 +1,6 @@
 ---
 title: Parampreet Singh
+type: author
 ---
 Parampreet Singh is a Computer Science Undergraduate Student at Ohio Wesleyan University. He really likes working with new technologies and wants to be entrepreneur with the motto of helping the world be a better place.
 He is the founder of the website studentpath.co, where students can find free resources to learn anything they want. The website is growing period to include newest features in order to help the students in every possible way.

--- a/authors/peter-kayere/index.md
+++ b/authors/peter-kayere/index.md
@@ -1,4 +1,5 @@
 ---
 title: peter-kayere
+type: author
 ---
 Peter Kayere is a first-year undergraduate student at Jomo Kenyatta University of Agriculture and Technology studying Computer Technology. Peter has a great passion in software development particularly mobile web and android application development.

--- a/authors/peter-kayere/index.md
+++ b/authors/peter-kayere/index.md
@@ -1,5 +1,5 @@
 ---
 title: peter-kayere
-type: author
+type: engineering-education/author
 ---
 Peter Kayere is a first-year undergraduate student at Jomo Kenyatta University of Agriculture and Technology studying Computer Technology. Peter has a great passion in software development particularly mobile web and android application development.

--- a/authors/peter-kayere/index.md
+++ b/authors/peter-kayere/index.md
@@ -1,5 +1,5 @@
 ---
-title: peter-kayere
+title: Peter Kayere
 type: engineering-education/author
 ---
 Peter Kayere is a first-year undergraduate student at Jomo Kenyatta University of Agriculture and Technology studying Computer Technology. Peter has a great passion in software development particularly mobile web and android application development.

--- a/authors/peter-kayere/index.md
+++ b/authors/peter-kayere/index.md
@@ -1,4 +1,4 @@
 ---
-name: peter-kayere
+title: peter-kayere
 ---
 Peter Kayere is a first-year undergraduate student at Jomo Kenyatta University of Agriculture and Technology studying Computer Technology. Peter has a great passion in software development particularly mobile web and android application development.

--- a/authors/prathiksha-veera/index.md
+++ b/authors/prathiksha-veera/index.md
@@ -1,5 +1,6 @@
 ---
 title: Prathiksha Veera
+type: author
 ---
 
 Prathiksha Veera is an aspiring writer and a fast learner. She is an adventurous person and open to take risks or new challenges. She is interested to learn more about the Computer engineering lately. Learning and writing about engineering related topics became a new adventure for her. She loves to do drawing and painting to take a break with purpose.

--- a/authors/prathiksha-veera/index.md
+++ b/authors/prathiksha-veera/index.md
@@ -1,5 +1,5 @@
 ---
-name: Prathiksha Veera
+title: Prathiksha Veera
 ---
 
 Prathiksha Veera is an aspiring writer and a fast learner. She is an adventurous person and open to take risks or new challenges. She is interested to learn more about the Computer engineering lately. Learning and writing about engineering related topics became a new adventure for her. She loves to do drawing and painting to take a break with purpose.

--- a/authors/prathiksha-veera/index.md
+++ b/authors/prathiksha-veera/index.md
@@ -1,6 +1,6 @@
 ---
 title: Prathiksha Veera
-type: author
+type: engineering-education/author
 ---
 
 Prathiksha Veera is an aspiring writer and a fast learner. She is an adventurous person and open to take risks or new challenges. She is interested to learn more about the Computer engineering lately. Learning and writing about engineering related topics became a new adventure for her. She loves to do drawing and painting to take a break with purpose.

--- a/authors/priyank-kumar/index.md
+++ b/authors/priyank-kumar/index.md
@@ -1,4 +1,4 @@
 ---
-name: Priyank Kumar
+title: Priyank Kumar
 ---
 Priyank is an undergraduate student pursuing a degree in Computer Science & Engineering. Priyank is Data Science Enthusiast. He loves contributing to open source projects, and also involving himself in tech communities.

--- a/authors/priyank-kumar/index.md
+++ b/authors/priyank-kumar/index.md
@@ -1,5 +1,5 @@
 ---
 title: Priyank Kumar
-type: author
+type: engineering-education/author
 ---
 Priyank is an undergraduate student pursuing a degree in Computer Science & Engineering. Priyank is Data Science Enthusiast. He loves contributing to open source projects, and also involving himself in tech communities.

--- a/authors/priyank-kumar/index.md
+++ b/authors/priyank-kumar/index.md
@@ -1,4 +1,5 @@
 ---
 title: Priyank Kumar
+type: author
 ---
 Priyank is an undergraduate student pursuing a degree in Computer Science & Engineering. Priyank is Data Science Enthusiast. He loves contributing to open source projects, and also involving himself in tech communities.

--- a/authors/ria-thakkar/index.md
+++ b/authors/ria-thakkar/index.md
@@ -1,5 +1,5 @@
 ---
 title: Ria Thakkar
-type: author
+type: engineering-education/author
 ---
 Ria Thakkar is a computer science student at the University of Colorado at Boulder. She is an active member of Girls Who Code and in her free time enjoys teaching others how to code, and planespotting at the local airport.

--- a/authors/ria-thakkar/index.md
+++ b/authors/ria-thakkar/index.md
@@ -1,4 +1,4 @@
 ---
-name: Ria Thakkar
+title: Ria Thakkar
 ---
 Ria Thakkar is a computer science student at the University of Colorado at Boulder. She is an active member of Girls Who Code and in her free time enjoys teaching others how to code, and planespotting at the local airport.

--- a/authors/ria-thakkar/index.md
+++ b/authors/ria-thakkar/index.md
@@ -1,4 +1,5 @@
 ---
 title: Ria Thakkar
+type: author
 ---
 Ria Thakkar is a computer science student at the University of Colorado at Boulder. She is an active member of Girls Who Code and in her free time enjoys teaching others how to code, and planespotting at the local airport.

--- a/authors/richu-thomas/index.md
+++ b/authors/richu-thomas/index.md
@@ -1,4 +1,5 @@
 ---
 title: Richu Thomas
+type: author
 ---
 Richu Thomas a student of DPG Institute of Technology and Management in India. He is a GitHub Campus Expert and leads the Developers Student Club and the Hack Club on his campus. He is always interested in learning new things both on and off the campus.

--- a/authors/richu-thomas/index.md
+++ b/authors/richu-thomas/index.md
@@ -1,4 +1,4 @@
 ---
-name: Richu Thomas
+title: Richu Thomas
 ---
 Richu Thomas a student of DPG Institute of Technology and Management in India. He is a GitHub Campus Expert and leads the Developers Student Club and the Hack Club on his campus. He is always interested in learning new things both on and off the campus.

--- a/authors/richu-thomas/index.md
+++ b/authors/richu-thomas/index.md
@@ -1,5 +1,5 @@
 ---
 title: Richu Thomas
-type: author
+type: engineering-education/author
 ---
 Richu Thomas a student of DPG Institute of Technology and Management in India. He is a GitHub Campus Expert and leads the Developers Student Club and the Hack Club on his campus. He is always interested in learning new things both on and off the campus.

--- a/authors/rohan-reddy/index.md
+++ b/authors/rohan-reddy/index.md
@@ -1,4 +1,4 @@
 ---
-name: Rohan Reddy
+title: Rohan Reddy
 ---
 Rohan Reddy is an undergraduate student at the University of Hyderabad pursuing a degree in Computer Science. Rohan is particularly interested in machine learning and web development.

--- a/authors/rohan-reddy/index.md
+++ b/authors/rohan-reddy/index.md
@@ -1,4 +1,5 @@
 ---
 title: Rohan Reddy
+type: author
 ---
 Rohan Reddy is an undergraduate student at the University of Hyderabad pursuing a degree in Computer Science. Rohan is particularly interested in machine learning and web development.

--- a/authors/rohan-reddy/index.md
+++ b/authors/rohan-reddy/index.md
@@ -1,5 +1,5 @@
 ---
 title: Rohan Reddy
-type: author
+type: engineering-education/author
 ---
 Rohan Reddy is an undergraduate student at the University of Hyderabad pursuing a degree in Computer Science. Rohan is particularly interested in machine learning and web development.

--- a/authors/saiharsha-balasubramaniam/index.md
+++ b/authors/saiharsha-balasubramaniam/index.md
@@ -1,4 +1,4 @@
 ---
-name: Saiharsha Balasubramaniam
+title: Saiharsha Balasubramaniam
 ---
 Saiharsha Balasubramaniam is a Computer Science Undergrad at Amrita Vishwa Vidyapeetham University, India. He is also a passionate software developer and an avid researcher. He designs and develops aesthetic websites, and loves blockchain technology. While he is not programming, he usually binges NetFlix or can be seen reading a book.

--- a/authors/saiharsha-balasubramaniam/index.md
+++ b/authors/saiharsha-balasubramaniam/index.md
@@ -1,5 +1,5 @@
 ---
 title: Saiharsha Balasubramaniam
-type: author
+type: engineering-education/author
 ---
 Saiharsha Balasubramaniam is a Computer Science Undergrad at Amrita Vishwa Vidyapeetham University, India. He is also a passionate software developer and an avid researcher. He designs and develops aesthetic websites, and loves blockchain technology. While he is not programming, he usually binges NetFlix or can be seen reading a book.

--- a/authors/saiharsha-balasubramaniam/index.md
+++ b/authors/saiharsha-balasubramaniam/index.md
@@ -1,4 +1,5 @@
 ---
 title: Saiharsha Balasubramaniam
+type: author
 ---
 Saiharsha Balasubramaniam is a Computer Science Undergrad at Amrita Vishwa Vidyapeetham University, India. He is also a passionate software developer and an avid researcher. He designs and develops aesthetic websites, and loves blockchain technology. While he is not programming, he usually binges NetFlix or can be seen reading a book.

--- a/authors/shreya-a-n/index.md
+++ b/authors/shreya-a-n/index.md
@@ -1,4 +1,4 @@
 ---
-name: Shreya A N
+title: Shreya A N
 ---
 Shreya A N is a senior at JSS Science and Technology University, India and a Network Security Intern at Cisco. She is passionate about computer networks, machine learning and data science. Shreya likes to spend her leisure time cooking, reading and making music.

--- a/authors/shreya-a-n/index.md
+++ b/authors/shreya-a-n/index.md
@@ -1,4 +1,5 @@
 ---
 title: Shreya A N
+type: author
 ---
 Shreya A N is a senior at JSS Science and Technology University, India and a Network Security Intern at Cisco. She is passionate about computer networks, machine learning and data science. Shreya likes to spend her leisure time cooking, reading and making music.

--- a/authors/shreya-a-n/index.md
+++ b/authors/shreya-a-n/index.md
@@ -1,5 +1,5 @@
 ---
 title: Shreya A N
-type: author
+type: engineering-education/author
 ---
 Shreya A N is a senior at JSS Science and Technology University, India and a Network Security Intern at Cisco. She is passionate about computer networks, machine learning and data science. Shreya likes to spend her leisure time cooking, reading and making music.

--- a/authors/sophia-raji/index.md
+++ b/authors/sophia-raji/index.md
@@ -1,4 +1,4 @@
 ---
-name: Sophia R.
+title: Sophia R.
 ---
 Sophia R. is a junior in computer science at Columbia University. She takes particular interest in full-stack web development and Bitcoin programming. When she is not working on side projects, she teaches coding to middle school and high school students and writes a satire website.

--- a/authors/sophia-raji/index.md
+++ b/authors/sophia-raji/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sophia R.
+title: Sophia Raji
 type: engineering-education/author
 ---
 Sophia R. is a junior in computer science at Columbia University. She takes particular interest in full-stack web development and Bitcoin programming. When she is not working on side projects, she teaches coding to middle school and high school students and writes a satire website.

--- a/authors/sophia-raji/index.md
+++ b/authors/sophia-raji/index.md
@@ -1,5 +1,5 @@
 ---
 title: Sophia R.
-type: author
+type: engineering-education/author
 ---
 Sophia R. is a junior in computer science at Columbia University. She takes particular interest in full-stack web development and Bitcoin programming. When she is not working on side projects, she teaches coding to middle school and high school students and writes a satire website.

--- a/authors/sophia-raji/index.md
+++ b/authors/sophia-raji/index.md
@@ -1,4 +1,5 @@
 ---
 title: Sophia R.
+type: author
 ---
 Sophia R. is a junior in computer science at Columbia University. She takes particular interest in full-stack web development and Bitcoin programming. When she is not working on side projects, she teaches coding to middle school and high school students and writes a satire website.

--- a/authors/zack-jorquera/index.md
+++ b/authors/zack-jorquera/index.md
@@ -1,4 +1,5 @@
 ---
 title: Zack Jorquera
+type: author
 ---
 Zack Jorquera is a sophomore at CU Boulder pursuing a degree in computer science and applied mathematics. Zack's key interest is systems programming.

--- a/authors/zack-jorquera/index.md
+++ b/authors/zack-jorquera/index.md
@@ -1,4 +1,4 @@
 ---
-name: Zack Jorquera
+title: Zack Jorquera
 ---
 Zack Jorquera is a sophomore at CU Boulder pursuing a degree in computer science and applied mathematics. Zack's key interest is systems programming.

--- a/authors/zack-jorquera/index.md
+++ b/authors/zack-jorquera/index.md
@@ -1,5 +1,5 @@
 ---
 title: Zack Jorquera
-type: author
+type: engineering-education/author
 ---
 Zack Jorquera is a sophomore at CU Boulder pursuing a degree in computer science and applied mathematics. Zack's key interest is systems programming.


### PR DESCRIPTION
On articles:

- Specify `url`, to ensure article URLs stay the same
- Remove `slug`, as it's ignored once `url:` is set

On authors: 

- Rename `name` to `title`, so author pages can be generated
- Specify `type`, so the correct template can be looked up (`layouts/engineering-education/author/single.html`)