### PR TITLE
Remove topic pages that aren't actually used

### DIFF
--- a/topic/containers/_index.md
+++ b/topic/containers/_index.md
@@ -1,3 +1,0 @@
----
-title: Containers
----

--- a/topic/edge-computing/_index.md
+++ b/topic/edge-computing/_index.md
@@ -1,3 +1,0 @@
----
-title: Edge Computing
----

--- a/topic/languages/_index.md
+++ b/topic/languages/_index.md
@@ -1,3 +1,0 @@
----
-title: Languages
----

--- a/topic/networking/_index.md
+++ b/topic/networking/_index.md
@@ -1,3 +1,0 @@
----
-title: Networking
----

--- a/topic/nodejs/_index.md
+++ b/topic/nodejs/_index.md
@@ -1,3 +1,0 @@
----
-title: Node.js
----

--- a/topic/security/_index.md
+++ b/topic/security/_index.md
@@ -1,3 +1,0 @@
----
-title: Security
----


### PR DESCRIPTION
Turns out that topic page templates are sourced from outside this repo! 

Removing these templates, as they don't actually do anything. 