### PR TITLE
Fix a bug in code snippet in nodejs-enviornment-variables article

### DIFF
--- a/articles/nodejs-environment-variables/index.md
+++ b/articles/nodejs-environment-variables/index.md
@@ -63,10 +63,10 @@ Create a file called `index.js` and add the following code to it.
 
 ```js
 const express = require("express");
+require("dotenv").config();
+
 const app = express();
 const port = process.env.PORT || 3000;
-
-require("dotenv").config();
 
 app.listen(port, () => {
   console.log(`Server is running on the port ${port}.`);


### PR DESCRIPTION
There was a bug in the provided code snippet as the env variable `PORT` was referenced to be used **before** environment variables were parsed using the `.config` function.